### PR TITLE
Add Buildkite pipeline

### DIFF
--- a/.buildkite/npm-build.sh
+++ b/.buildkite/npm-build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- Install node_modules"
+
+npm install
+
+echo "--- Build"
+
+npm run build
+
+echo "--- Test"
+
+npx tsdx test --collect-coverage 
+
+echo "--- Rebuild docs"
+
+npm run typedoc

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,6 @@
+steps:
+  - label: 'npm build'
+    command: "nix-shell --pure --run .buildkite/npm-build.sh"
+    timeout_in_minutes: 30
+    agents:
+      system: x86_64-linux

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 /site/
 /docs/*.html
 /docs/*.png
+/coverage/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Alternatively, to run only unit tests:
 
     npx tsdx test unit
 
+See the [Jest command-line reference](https://jestjs.io/docs/en/cli)
+for all the options.
+
 ### `npm run typedoc`
 
 Generates API documentation to the `site` folder.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cardano-launcher Shelley
 
+[![Build status](https://badge.buildkite.com/98083d5651511146dab7911b99f20ff9b60b4f8be25298a82f.svg)](https://buildkite.com/input-output-hk/cardano-launcher)
+
 `cardano-launcher` is a Node.js module for starting
 [cardano-wallet](https://github.com/input-output-hk/cardano-wallet)
 and the Shelley

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ with pkgs;
 mkShell {
   buildInputs = [
     # javascript
-    nodePackages.npm
+    nodejs nodePackages.npm
     # documentation tools
     pandoc mscgen librsvg gnumake
     # util to update nixpkgs pins


### PR DESCRIPTION
- Adds an npm build for Buildkite
- Buildkite doesn't have permission to clone this private repo - so it needs to be public before CI works.