### PR TITLE
Update cardano-wallet version and fix test config

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {
-        "branch": "rvl/1314/launcher-shutdown-handler",
+        "branch": "master",
         "description": "Official Wallet Backend & API for Cardano decentralized",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "e0aed8a146c5de96205d591b11b0e5c577eb3db7",
-        "sha256": "0sz2gxmd9m74q5mn600r7jfqxwan17v9j37b2whapcmnj1gmwhin",
+        "rev": "49dfa23c22251c08db01ed3a11f0a594eb6888b8",
+        "sha256": "083shvk9sc8wpxifxi0wxlcz5i869g8z5zyj2j0k4iiz20kpwz4r",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/e0aed8a146c5de96205d591b11b0e5c577eb3db7.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/49dfa23c22251c08db01ed3a11f0a594eb6888b8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "0c17bb046335f43a8facfbf82a588820360f9514"
     },

--- a/test/data/jormungandr/config.yaml
+++ b/test/data/jormungandr/config.yaml
@@ -1,3 +1,4 @@
+skip_bootstrap: true
 p2p:
   trusted_peers: []
   topics_of_interest:


### PR DESCRIPTION
Windows tests (which always use the latest build of cardano-wallet-jormungandr) were failing with:

```
...
Mar 01 21:46:17.620 ERRO trusted-peers cannot be empty. to avoid bootstrap use 'skip_bootstrap: true', task: bootstrap
Mar 01 21:46:17.620 INFO bootstrap attempt #139 failed, trying again in 5 seconds..., task: bootstrap
...
```

This updates the `config.yaml` used for tests.
