### PR TITLE
DDW-25 Use cardano-node version specified by cardano-wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,21 @@ Runs a bash shell with project development dependencies (e.g. `npm`,
 See [nix.md](https://github.com/input-output-hk/iohk-nix/blob/master/docs/nix.md)
 for information on how to set up Nix.
 
-### Updating cardano-wallet versiion
+### Updating cardano-wallet version
 
 To modify the cardano-wallet version, use [`niv update`](https://github.com/nmattia/niv#update).
 
     nix-shell --run "niv update cardano-wallet"
 
-To modify the cardano-node version, also use `niv-update`.
+The version of `cardano-node` and `jormungandr` are defined by
+cardano-wallet because it has specific version requirements for its
+backends.
 
-    nix-shell --run "niv update cardano-node"
+#### Overriding node backend versions
 
-In future, the `cardano-node` version may be defined by
-`cardano-wallet`, is it is for `jormungandr`.
+To use your own build of `cardano-node` or `jormungandr`, export your
+`PATH` environment variable so that your build is ahead of those set
+by the `nix-shell`.
 
 ## Design docs
 

--- a/nix/nivpkgs.nix
+++ b/nix/nivpkgs.nix
@@ -3,10 +3,6 @@ with
   { overlay = self: pkgs:
       { niv = import sources.niv {};
         cardanoWalletPackages = import sources.cardano-wallet {};
-        cardano-node = (import sources.cardano-node {}).nix-tools.cexes.cardano-node.cardano-node // {
-          # provide configuration directory as a convenience
-          configs = sources.cardano-node + /configuration;
-        };
         inherit (import sources.iohk-nix) jormungandrLib;
         jormungandrConfigs = self.jormungandrLib.forEnvironments self.jormungandrLib.mkConfigHydra;
       };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,14 @@
 {
-    "cardano-node": {
-        "branch": "master",
-        "description": null,
-        "homepage": null,
-        "owner": "input-output-hk",
-        "repo": "cardano-node",
-        "rev": "dd3829fb2e72c3da7a9720429a8b47b2230fb50c",
-        "sha256": "1lgn7dklr0gw9z5m5cjmi2a52b76l6pc1v2v0siix1nznlqvv5g8",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/dd3829fb2e72c3da7a9720429a8b47b2230fb50c.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "cardano-wallet": {
         "branch": "master",
         "description": "Official Wallet Backend & API for Cardano decentralized",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "49dfa23c22251c08db01ed3a11f0a594eb6888b8",
-        "sha256": "083shvk9sc8wpxifxi0wxlcz5i869g8z5zyj2j0k4iiz20kpwz4r",
+        "rev": "85baad638b318ec58f26ad40959c143498e81b2c",
+        "sha256": "13ckjmbjrlym3csplis0jk31zzqgf6xld7lnnjnhsq5ifl6f7gpv",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/49dfa23c22251c08db01ed3a11f0a594eb6888b8.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/85baad638b318ec58f26ad40959c143498e81b2c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "0c17bb046335f43a8facfbf82a588820360f9514"
     },

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ mkShell {
     cardanoWalletPackages.jormungandr
     # cardano byron
     cardanoWalletPackages.cardano-wallet-byron
-    cardano-node
+    cardanoWalletPackages.cardano-node
   ];
 
-  BYRON_CONFIGS = cardano-node.configs;
+  BYRON_CONFIGS = cardanoWalletPackages.cardano-node.configs;
 }


### PR DESCRIPTION
[DDW-25](https://jira.iohk.io/browse/DDW-25)

Sets the cardano-node version in the nix-shell to the very same version specified by cardano-wallet.

Depends on PR input-output-hk/cardano-wallet#1408.