### PR TITLE
Add stakePoolRegistryUrl to wallet launch config

### DIFF
--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -77,7 +77,7 @@ export interface LaunchConfig {
    * https://github.com/cardano-foundation/incentivized-testnet-stakepool-registry/archive/master.zip.
    */
   stakePoolRegistryUrl?: string;
-   
+
   /**
    * Maximum time difference (in seconds) between the tip slot and the
    * latest applied block within which we consider a wallet being

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -67,6 +67,18 @@ export interface LaunchConfig {
   listenAddress?: string;
 
   /**
+   * Overrides the URL to the zip file containing stake pool metadata
+   * which is downloaded by cardano-wallet.
+   *
+   * This is only useful in testing scenarios, or when running a local
+   * development testnet.
+   *
+   * For Jörmungandr ITN, the default is
+   * https://github.com/cardano-foundation/incentivized-testnet-stakepool-registry/archive/master.zip.
+   */
+  stakePoolRegistryUrl?: string;
+
+  /**
    * Configuration for starting `cardano-node`. The `kind` property will be one of
    *  * `"byron"` - [[ByronNodeConfig]]
    *  * `"shelley"` - [[ShelleyNodeConfig]]
@@ -408,6 +420,9 @@ async function walletExe(
     ].concat(
       config.listenAddress ? ['--listen-address', config.listenAddress] : []
     ),
+    extraEnv: config.stakePoolRegistryUrl
+      ? { CARDANO_WALLET_STAKE_POOL_REGISTRY_URL: config.stakePoolRegistryUrl }
+      : undefined,
     supportsCleanShutdown: true,
     apiPort,
   };


### PR DESCRIPTION
This is used by Daedalus when running a local development testnet (Jörmungandr "self node").