### PR TITLE
Fix cardano-wallet-byron serve cli arguments

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "bbdf9f8a546f8018bfa18641ca52847b43f2dab2",
-        "sha256": "0h6fskkfzh8nq2b42mp5fxmw23dln2z745bw282mdr6fd2214nrf",
+        "rev": "fe984a815c2b1221f52f3107f515b825f37d2221",
+        "sha256": "16slkq5s1625sxykqr2j32vjlkb1zdgck00m3iw4ig8lkwjal552",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/bbdf9f8a546f8018bfa18641ca52847b43f2dab2.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/fe984a815c2b1221f52f3107f515b825f37d2221.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "v2020-03-11"
     },

--- a/src/byron.ts
+++ b/src/byron.ts
@@ -45,11 +45,10 @@ export interface ByronNodeConfig {
   network: ByronNetwork;
 
   /**
-   * Directory which will contain a socket file to use for
-   * communicating with the node. Optional -- will be set
-   * automatically if not provided.
+   * Filename for the socket to use for communicating with the
+   * node. Optional -- will be set automatically if not provided.
    */
-  socketDir?: DirPath;
+  socketFile?: FilePath;
 }
 
 /**
@@ -57,10 +56,10 @@ export interface ByronNodeConfig {
  */
 export interface ByronNodeArgs {
   /**
-   * Directory which will contain a socket file to use for
-   * communicating with the node.
+   * Filename for the socket file to use for communicating with the
+   * node.
    */
-  socketDir: DirPath;
+  socketFile: FilePath;
 
   /**
    * The path to a file describing the topology.
@@ -114,11 +113,11 @@ function makeArgs(
   config: ByronNodeConfig,
   listenPort: number
 ): ByronNodeArgs {
-  if (!config.socketDir) {
-    config.socketDir = 'sockets'; // relative to working directory
+  if (!config.socketFile) {
+    config.socketFile = 'cardano-node.socket'; // relative to working directory
   }
   return {
-    socketDir: config.socketDir,
+    socketFile: config.socketFile,
     topologyFile: path.join(
       config.configurationDir,
       config.network.topologyFile
@@ -151,8 +150,9 @@ export async function startByronNode(
   return {
     command: 'cardano-node',
     args: [
-      '--socket-dir',
-      args.socketDir,
+      'run',
+      '--socket-path',
+      args.socketFile,
       '--topology',
       args.topologyFile,
       '--database-path',

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -449,9 +449,11 @@ async function walletExe(
       ]);
     case 'byron':
       return addArgs(
-        config.nodeConfig.socketDir
-          ? ['--node-socket', config.nodeConfig.socketDir]
-          : []
+        [`--${config.networkName}`].concat(
+          config.nodeConfig.socketFile
+            ? ['--node-socket', config.nodeConfig.socketFile]
+            : []
+        )
       );
     case 'shelley':
       return base;


### PR DESCRIPTION
- Updates cardano-wallet to use input-output-hk/cardano-wallet#1437 so that the byron backend will work.
- Updates some cli arguments in the wallet and node which changed recently.