### PR TITLE
Write a test case ensuring invalid path to config produces meaningful error

### DIFF
--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -221,7 +221,9 @@ export class Launcher {
 
     return new Promise((resolve, reject) => {
       this.walletBackend.events.on('ready', resolve);
-      this.walletBackend.events.on('exit', reject);
+      this.walletBackend.events.on('exit', st =>
+        reject(new BackendExitedError(st))
+      );
     });
   }
 
@@ -353,6 +355,19 @@ class V2Api implements Api {
 export interface ExitStatus {
   wallet: ServiceExitStatus;
   node: ServiceExitStatus;
+}
+
+/**
+ * This instance of [[Error]] will be returned when the
+ * `Launcher.start()` promise is rejected.
+ */
+export class BackendExitedError extends Error {
+  status: ExitStatus;
+  constructor(status: ExitStatus) {
+    super(exitStatusMessage(status));
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.status = status;
+  }
 }
 
 /**

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -211,7 +211,11 @@ export class Launcher {
     this.nodeService.start();
     this.walletService.start();
 
-    this.waitForApi().then(() => {
+    const stopWaiting = () =>
+      this.nodeService.getStatus() > ServiceStatus.Started ||
+      this.walletService.getStatus() > ServiceStatus.Started;
+
+    this.waitForApi(stopWaiting).then(() => {
       this.walletBackend.events.emit('ready', this.walletBackend.getApi());
     });
 
@@ -223,16 +227,19 @@ export class Launcher {
 
   /**
    * Poll TCP port of wallet API server until it accepts connections.
-   * @param port - TCP port number
+   * @param stop - a callback, which will terminate the polling loop if it returns a truey value.
    * @return a promise that is completed once the wallet API server accepts connections.
    */
-  private waitForApi(): Promise<void> {
+  private waitForApi(stop: () => boolean): Promise<void> {
     this.logger.debug('waitForApi');
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       let addr: net.SocketConnectOpts;
       var client: net.Socket;
       const poll = () => {
-        if (this.apiPort) {
+        if (stop()) {
+          clearInterval(timer);
+          reject();
+        } else if (this.apiPort) {
           if (!addr) {
             addr = { port: this.apiPort, host: '127.0.0.1' };
             this.logger.info(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -112,6 +112,27 @@ describe('Starting cardano-wallet (and its node)', () => {
     expect(events.length).toBe(1);
   });
 
+  it('handles case where node fails to start', async () => {
+    const launcher = await setupTestLauncher(stateDir => {
+      return {
+        stateDir,
+        networkName: 'self',
+        nodeConfig: {
+          kind: 'jormungandr',
+          configurationDir: path.join('test', 'data', 'jormungandr'),
+          network: jormungandr.networks.self,
+          extraArgs: ['--yolo'], // not a jormungandr arg
+        },
+      };
+    });
+    await expect(launcher.start()).rejects.toThrow(
+      [
+        'cardano-wallet-jormungandr exited with status 0',
+        'jormungandr exited with status 1',
+      ].join('\n')
+    );
+  });
+
   // cardano-wallet-byron is still wip
   xit(
     'cardano-wallet-byron responds to requests',


### PR DESCRIPTION
### Issue

Issue raised by @rhyslbw:

> Not a pressing issue since this will likely only apply to cardano-node since Jormungandr doesn't exit under this condition.

### Description

- [x] This makes `waitForApi()` stop if any of the backend services exit.
- [x] Adds a test case for when a service fails to start.

If the backend services fail to start then `cardano-launcher` will get stuck and not exit. This is probably the bug that @nikolaglumac saw.