### PR TITLE
Correct development-only deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and the Shelley
 
 Its primary user is
 [Daedalus](https://github.com/input-output-hk/daedalus); however it
-could be used by any Javascript application.
+could be used by any Javascript application. Tagged versions are published to the [npm Registry](https://www.npmjs.com/package/cardano-launcher) as `cardano-launcher`.
 
 ## Documentation
 
@@ -42,7 +42,7 @@ Bundles the package to the `dist` folder.
 
 Runs the test watcher ([Jest](https://jestjs.io/docs/en/getting-started))
 in an interactive mode.
-By default, runs tests related to files changed since the last commit.
+By default, runs tests related to files changed since the last commit. 
 
 Alternatively, to run only unit tests:
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   },
   "devDependencies": {
     "@types/jest": "^24.9.0",
+    "@types/lodash": "^4.14.149",
     "@types/mkdirp": "^1.0.0",
+    "@types/node": "^13.1.8",
     "husky": "^4.0.10",
     "tmp-promise": "^2.0.2",
     "ts-node": "^8.6.2",
@@ -45,8 +47,6 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.149",
-    "@types/node": "^13.1.8",
     "get-port": "^5.1.1",
     "lodash": "^4.17.15",
     "mkdirp": "^1.0.3",


### PR DESCRIPTION
Also adds a note to the `README` about where to access a packaged build. Superseeds #25 