### PR TITLE
Support cardano-wallet-byron --testnet genesis arg

### DIFF
--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -486,8 +486,13 @@ async function walletExe(
         '' + config.nodeConfig.restPort,
       ]);
     case 'byron':
+      const networkArg =
+        config.networkName === 'mainnet'
+          ? ['--mainnet']
+          : ['--testnet', config.nodeConfig.network.genesisFile];
+
       return addArgs(
-        [`--${config.networkName}`].concat(
+        networkArg.concat(
           config.nodeConfig.socketFile
             ? ['--node-socket', config.nodeConfig.socketFile]
             : []


### PR DESCRIPTION
Supports the cardano-wallet-byron --testnet option which requires a genesis file as its argument.

Resolves #40