### PR TITLE
Implement strict linting to resolve test suite failures

### DIFF
--- a/.buildkite/npm-build.sh
+++ b/.buildkite/npm-build.sh
@@ -14,9 +14,9 @@ echo "--- Test"
 
 npm run test -- --collect-coverage
 
-#echo "--- Lint"
+echo "--- Lint"
 
-#npm run lint
+npm run lint
 
 echo "--- Rebuild docs"
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,10 @@
 {
-  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "standard-with-typescript"
+  ],
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "extends": [
-    "standard"
-  ],
   "plugins": [
     "@typescript-eslint",
     "jest"
@@ -19,12 +18,12 @@
     "afterEach": "readonly"
   },
   "rules": {
-    "no-unused-vars": 0,
     "linebreak-style": [
       2,
       "unix"
     ],
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "no-unused-vars": 0
   },
   "env": {
     "jest": true

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ for example code.
 
 
 ## Local Development
+[![JavaScript Style Guide](https://cdn.rawgit.com/standard/standard/master/badge.svg)](https://github.com/standard/standard)
 
 ### `npm run build` `npm run build -- --watch`
 
@@ -50,7 +51,8 @@ See the [Jest command-line reference](https://jestjs.io/docs/en/cli) for all the
 
 ### `npm run lint` `npm run lint -- --fix`
 
-[JavaScript Standard Style](https://standardjs.com/)
+[eslint-config-standard-with-typescriopt](https://github.com/standard/eslint-config-standard-with-typescript) provides the code style rules.
+See the [eslintrc](./.eslintrc.json) for details.
 
 ### `npm run typedoc`
 

--- a/bin/cardano-launcher
+++ b/bin/cardano-launcher
@@ -3,4 +3,4 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
-require('../dist/cli').cli(process.argv);
+require('../dist/cli').cli(process.argv)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
-};
+  testEnvironment: 'node'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,7 +1337,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1738,8 +1737,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1789,7 +1787,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1916,7 +1913,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1924,8 +1920,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1960,6 +1955,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2263,8 +2269,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -2340,6 +2345,16 @@
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
       "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
       "dev": true
+    },
+    "eslint-config-standard-with-typescript": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-15.0.1.tgz",
+      "integrity": "sha512-Bsk21CA1WV5K+MVrYM8CV7dbnflNFmrL22Dahi3M3VQp8hPFVnsAlgXmN9CMTXEKpP048semsZeIdYQttSoqBA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^2.24.0",
+        "eslint-config-standard": "^14.1.1"
+      }
     },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
@@ -3310,8 +3325,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3539,8 +3553,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "7.1.0",
@@ -6459,8 +6472,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7070,6 +7082,16 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -7779,6 +7801,35 @@
         }
       }
     },
+    "snazzy": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
+      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
+      "requires": {
+        "chalk": "^2.3.0",
+        "inherits": "^2.0.1",
+        "minimist": "^1.1.1",
+        "readable-stream": "^3.0.2",
+        "standard-json": "^1.0.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7884,6 +7935,14 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
+    "standard-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.1.0.tgz",
+      "integrity": "sha512-nkonX+n5g3pyVBvJZmvRlFtT/7JyLbNh4CtrYC3Qfxihgs8PKX52f6ONKQXORStuBWJ5PI83EUrNXme7LKfiTQ==",
+      "requires": {
+        "concat-stream": "^2.0.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7969,6 +8028,21 @@
         "function-bind": "^1.1.1"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -8006,7 +8080,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -8105,8 +8178,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "throat": {
       "version": "5.0.0",
@@ -8301,6 +8373,11 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8476,6 +8553,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,6 +1337,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1737,7 +1738,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1787,6 +1789,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1913,6 +1916,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1920,7 +1924,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1955,17 +1960,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2269,7 +2263,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.1",
@@ -3325,7 +3320,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3553,7 +3549,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "inquirer": {
       "version": "7.1.0",
@@ -6472,7 +6469,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7082,16 +7080,6 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -7801,35 +7789,6 @@
         }
       }
     },
-    "snazzy": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/snazzy/-/snazzy-8.0.0.tgz",
-      "integrity": "sha512-59GS69hQD8FvJoNGeDz8aZtbYhkCFxCPQB1BFzAWiVVwPmS/J6Vjaku0k6tGNsdSxQ0kAlButdkn8bPR2hLcBw==",
-      "requires": {
-        "chalk": "^2.3.0",
-        "inherits": "^2.0.1",
-        "minimist": "^1.1.1",
-        "readable-stream": "^3.0.2",
-        "standard-json": "^1.0.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7935,14 +7894,6 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
-    "standard-json": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/standard-json/-/standard-json-1.1.0.tgz",
-      "integrity": "sha512-nkonX+n5g3pyVBvJZmvRlFtT/7JyLbNh4CtrYC3Qfxihgs8PKX52f6ONKQXORStuBWJ5PI83EUrNXme7LKfiTQ==",
-      "requires": {
-        "concat-stream": "^2.0.0"
-      }
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -8028,21 +7979,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
-      }
-    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -8080,6 +8016,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -8178,7 +8115,8 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "throat": {
       "version": "5.0.0",
@@ -8373,11 +8311,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8553,11 +8486,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
     "eslint": "^6.8.0",
-    "eslint-config-standard": "^14.1.1",
+    "eslint-config-standard-with-typescript": "^15.0.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-node": "^11.1.0",

--- a/src/byron.ts
+++ b/src/byron.ts
@@ -127,7 +127,7 @@ function makeArgs (
   listenPort: number
 ): ByronNodeArgs {
   let socketFile = config.socketFile
-  if (!socketFile) {
+  if (socketFile === undefined) {
     if (process.platform === 'win32') {
       config.socketFile = socketFile = `\\\\.\\pipe\\cardano-node-${networkName}`
     } else {
@@ -156,6 +156,7 @@ function makeArgs (
  *
  * @param stateDir - directory for node storage, specific to the node type and network.
  * @param config - parameters for starting the node.
+ * @param networkName - network identifier
  * @return the command-line for starting this node.
  */
 export async function startByronNode (
@@ -176,15 +177,15 @@ export async function startByronNode (
       '--database-path',
       args.databaseDir,
       '--port',
-      '' + args.listen.port,
+      `${args.listen.port}`,
       '--config',
       args.configFile
     ]
-      .concat(args.listen.address ? ['--host-addr', args.listen.address] : [])
+      .concat(args.listen.address !== undefined ? ['--host-addr', args.listen.address] : [])
       .concat(args.validateDb ?? false ? ['--validate-db'] : [])
-      .concat(args.signingKey ? ['--signing-key', args.signingKey] : [])
+      .concat(args.signingKey !== undefined ? ['--signing-key', args.signingKey] : [])
       .concat(
-        args.delegationCertificate
+        args.delegationCertificate !== undefined
           ? ['--delegation-certificate', args.delegationCertificate]
           : []
       )

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -258,7 +258,7 @@ export class Launcher {
   private async waitForApi (stop: () => boolean): Promise<void> {
     this.logger.debug('waitForApi')
     return await new Promise((resolve, reject) => {
-      // let client: net.Socket
+      let client: net.Socket | undefined
       const poll = (): void => {
         if (stop()) {
           clearInterval(timer)
@@ -268,10 +268,10 @@ export class Launcher {
           this.logger.info(
             `Waiting for tcp port ${addr.host as string}:${addr.port} to accept connections...`
           )
-          // if (client !== undefined) {
-          //   client.destroy()
-          // }
-          const client = new net.Socket()
+          if (client !== undefined) {
+            client.destroy()
+          }
+          client = new net.Socket()
           client.connect(addr, () => {
             this.logger.info('... port is ready.')
             clearInterval(timer)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,121 +11,120 @@
  * @packageDocumentation
  */
 
-import _ from 'lodash';
-import process from 'process';
-import Process = NodeJS.Process;
+import _ from 'lodash'
+import process from 'process'
 
 import {
-  Launcher,
-  ExitStatus
-} from './cardanoLauncher';
+  ExitStatus,
+  Launcher
+} from './cardanoLauncher'
 
 import {
   ServiceExitStatus,
-  serviceExitStatusMessage,
-} from './service';
-import * as byron from './byron';
-import * as jormungandr from './jormungandr';
+  serviceExitStatusMessage
+} from './service'
+import * as byron from './byron'
+import * as jormungandr from './jormungandr'
 
 /**
  * Main function of the CLI.
  *
  * Is just a very basic interface for testing things.
  */
-export function cli(argv: Process['argv']) {
+export function cli (argv: NodeJS.Process['argv']) {
   const waitForExit = setInterval(function () {
-  }, 3600000);
-  const args = argv;
+  }, 3600000)
+  const args = argv
 
-  args.shift(); // /usr/bin/node
-  args.shift(); // cardano-launcher
+  args.shift() // /usr/bin/node
+  args.shift() // cardano-launcher
 
   if (args.length < 4) {
-    usage();
+    usage()
   }
 
-  const backend = args.shift() as string;
-  const networkName = args.shift() as string;
-  const configurationDir = args.shift() as string;
-  const stateDir = args.shift() as string;
+  const backend = args.shift() as string
+  const networkName = args.shift() as string
+  const configurationDir = args.shift() as string
+  const stateDir = args.shift() as string
 
-  let nodeConfig: any;
+  let nodeConfig: any
 
   if (backend === 'byron') {
     if (!(networkName in byron.networks)) {
-      console.error(`unknown network: ${networkName}`);
-      process.exit(2);
+      console.error(`unknown network: ${networkName}`)
+      process.exit(2)
     }
-    const network = byron.networks[networkName];
+    const network = byron.networks[networkName]
     nodeConfig = {
       kind: backend,
       configurationDir,
-      network,
-    };
+      network
+    }
   } else if (backend === 'jormungandr') {
     if (!(networkName in jormungandr.networks)) {
-      console.error(`unknown network: ${networkName}`);
-      process.exit(2);
+      console.error(`unknown network: ${networkName}`)
+      process.exit(2)
     }
-    const network = jormungandr.networks[networkName];
+    const network = jormungandr.networks[networkName]
     nodeConfig = {
       kind: backend,
       configurationDir,
-      network,
-    };
+      network
+    }
   } else {
-    usage();
+    usage()
   }
 
-  const launcher = new Launcher({stateDir, nodeConfig, networkName}, console);
+  const launcher = new Launcher({ stateDir, nodeConfig, networkName }, console)
 
-  launcher.start();
+  launcher.start()
 
   // inform tests of subprocess pids
-  launcher.nodeService.start().then(pid => sendMaybe({node: pid}));
-  launcher.walletService.start().then(pid => sendMaybe({wallet: pid}));
+  launcher.nodeService.start().then(pid => sendMaybe({ node: pid }))
+  launcher.walletService.start().then(pid => sendMaybe({ wallet: pid }))
 
   launcher.walletBackend.events.on('exit', (status: ExitStatus) => {
-    console.log(serviceExitStatusMessage(status.wallet));
-    console.log(serviceExitStatusMessage(status.node));
-    clearInterval(waitForExit);
-    process.exit(combineStatus([status.wallet, status.node]));
-  });
+    console.log(serviceExitStatusMessage(status.wallet))
+    console.log(serviceExitStatusMessage(status.node))
+    clearInterval(waitForExit)
+    process.exit(combineStatus([status.wallet, status.node]))
+  })
 }
 
-function combineStatus(statuses: ServiceExitStatus[]): number {
-  let code = _.reduce(
+function combineStatus (statuses: ServiceExitStatus[]): number {
+  const code = _.reduce(
     statuses,
     (res: number | null, status) => (res === null ? status.code : res),
     null
-  );
-  let signal = _.reduce(
+  )
+  const signal = _.reduce(
     statuses,
     (res: string | null, status) => (res === null ? status.signal : res),
     null
-  );
+  )
   // let err = _.reduce(statuses, (res, status) => res === null ? status.err : res, null);
 
-  return code === null ? (signal === null ? 0 : 127) : code;
+  return code === null ? (signal === null ? 0 : 127) : code
 }
 
-function usage() {
-  console.log('usage: cardano-launcher BACKEND NETWORK CONFIG-DIR STATE-DIR');
-  console.log('  BACKEND    - either jormungandr or byron');
+function usage () {
+  console.log('usage: cardano-launcher BACKEND NETWORK CONFIG-DIR STATE-DIR')
+  console.log('  BACKEND    - either jormungandr or byron')
   console.log(
     '  NETWORK    - depends on backend, e.g. mainnet, itn_rewards_v1'
-  );
+  )
   console.log(
     '  CONFIG-DIR - directory which contains config files for a backend'
-  );
-  console.log('  STATE-DIR  - directory to put blockchains, databases, etc.');
-  process.exit(1);
+  )
+  console.log('  STATE-DIR  - directory to put blockchains, databases, etc.')
+  process.exit(1)
 }
 
-function sendMaybe(message: object) {
+function sendMaybe (message: object) {
   if (process.send) {
-    process.send(message);
+    process.send(message)
   }
 }
 
-cli(process.argv);
+cli(process.argv)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,12 +87,11 @@ export async function cli (argv: NodeJS.Process['argv']): Promise<void> {
   try {
     await launcher.start()
     const nodePid = await launcher.nodeService.start()
+    const walletPid = await launcher.walletService.start()
     // inform tests of subprocess pids
-    sendMaybe({ node: nodePid })
-    const walletPid = launcher.walletService.start()
-    sendMaybe({ wallet: walletPid })
+    sendMaybe({ nodePid, walletPid })
   } catch (error) {
-    sendMaybe(error.message)
+    console.error(error.message)
   }
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -8,6 +8,6 @@
  */
 
 /** Type alias to indicate the path of a file. */
-export type FilePath = string;
+export type FilePath = string
 /** Type alias to indicate the path of a directory. */
-export type DirPath = string;
+export type DirPath = string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
-export * from './cardanoLauncher';
+export * from './cardanoLauncher'

--- a/src/jormungandr.ts
+++ b/src/jormungandr.ts
@@ -7,11 +7,11 @@
  * @packageDocumentation
  */
 
-import path from 'path';
-import _ from 'lodash';
-import getPort from 'get-port';
-import { StartService } from './service';
-import { FilePath, DirPath } from './common';
+import path from 'path'
+import _ from 'lodash'
+import getPort from 'get-port'
+import { StartService } from './service'
+import { DirPath, FilePath } from './common'
 
 /**
  * Pre-defined networks for `jormungandr`. The "self" config is a
@@ -27,55 +27,55 @@ export const networks: { [propName: string]: JormungandrNetwork } = {
   itn_rewards_v1: {
     configFile: 'itn_rewards_v1-config.yaml',
     genesisBlock: {
-      hash: '8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676',
-    },
+      hash: '8e4d2a343f3dcf9330ad9035b3e8d168e6728904262f2c434a4f8f934ec7b676'
+    }
   },
   self: {
     configFile: 'config.yaml',
     genesisBlock: {
       file: 'block0.bin',
-      hash: 'f8c0622ea4b768421fea136a6e5a4e3b4c328fc5f16fad75817e40c8a2a56a56',
+      hash: 'f8c0622ea4b768421fea136a6e5a4e3b4c328fc5f16fad75817e40c8a2a56a56'
     },
-    secretFile: ['secret.yaml'],
-  },
-};
+    secretFile: ['secret.yaml']
+  }
+}
 
 /**
  * Definition of a Jörmungandr network.
  */
 export interface JormungandrNetwork {
-  configFile: FilePath;
-  genesisBlock: GenesisBlockHash | GenesisBlockFile;
-  secretFile?: FilePath[];
+  configFile: FilePath
+  genesisBlock: GenesisBlockHash | GenesisBlockFile
+  secretFile?: FilePath[]
 }
 
 /**
  * Configuration parameters for starting the node.
  */
 export interface JormungandrConfig {
-  kind: 'jormungandr';
+  kind: 'jormungandr'
 
   /** Directory containing configurations for all networks. */
-  configurationDir: DirPath;
+  configurationDir: DirPath
 
   /** Network parameters */
-  network: JormungandrNetwork;
+  network: JormungandrNetwork
 
   /** Optionally select a port for the node REST API. Otherwise, any unused port is chosen. */
-  restPort?: number;
+  restPort?: number
 
   /**
    * Extra arguments to add to the `jormungandr` command line.
    */
-  extraArgs?: string[];
+  extraArgs?: string[]
 }
 
 export interface GenesisBlockHash {
-  hash: string;
+  hash: string
 }
 
 export interface GenesisBlockFile extends GenesisBlockHash {
-  file: string;
+  file: string
 }
 
 /**
@@ -83,44 +83,44 @@ export interface GenesisBlockFile extends GenesisBlockHash {
  */
 export interface JormungandrArgs {
   /** Configuration file for the cardano-node. */
-  configFile: FilePath;
+  configFile: FilePath
 
   /** Directory where the state is stored. */
-  storageDir: DirPath;
+  storageDir: DirPath
 
   genesisBlock: {
     /** The file of the genesis block for this network's chain. */
-    file?: FilePath;
+    file?: FilePath
     /** The hash of the genesis block for this network's chain. */
-    hash?: string;
-  };
+    hash?: string
+  }
 
   /** BFT leaders secrets file(s). */
-  secretFile?: FilePath[];
+  secretFile?: FilePath[]
 
   /** Configures the address to bind for the REST API. */
-  restListen?: string;
+  restListen?: string
 
   /**
    * Extra arguments to add to the `jormungandr` command line.
    */
-  extra?: string[];
+  extra?: string[]
 }
-export async function startJormungandr(
+export async function startJormungandr (
   stateDir: DirPath,
   config: JormungandrConfig
 ): Promise<StartService> {
   if (!config.restPort) {
-    config.restPort = await getPort();
+    config.restPort = await getPort()
   }
-  const args = makeArgs(stateDir, config);
+  const args = makeArgs(stateDir, config)
   return {
     command: 'jormungandr',
     args: [
       '--config',
       args.configFile,
       '--storage',
-      args.storageDir,
+      args.storageDir
       // note: To support log file rotation from jormungandr, capture
       // its logs in json format and echo them into your frontend
       // logging framework (which presumably supports log rotation).
@@ -133,22 +133,22 @@ export async function startJormungandr(
         args.genesisBlock.file
           ? ['--genesis-block', args.genesisBlock.file]
           : args.genesisBlock.hash
-          ? ['--genesis-block-hash', args.genesisBlock.hash]
-          : []
+            ? ['--genesis-block-hash', args.genesisBlock.hash]
+            : []
       )
-      .concat(_.flatMap(args.secretFile || [], secret => ['--secret', secret]))
-      .concat(args.extra || []),
-    supportsCleanShutdown: false,
-  };
+      .concat(_.flatMap(args.secretFile ?? [], secret => ['--secret', secret]))
+      .concat(args.extra ?? []),
+    supportsCleanShutdown: false
+  }
 }
 
-function makeArgs(
+function makeArgs (
   stateDir: DirPath,
   config: JormungandrConfig
 ): JormungandrArgs {
   return {
     configFile: path.join(config.configurationDir, config.network.configFile),
-    restListen: `127.0.0.1:${config.restPort || 0}`,
+    restListen: `127.0.0.1:${config.restPort ?? 0}`,
     genesisBlock: {
       file:
         'file' in config.network.genesisBlock
@@ -157,12 +157,12 @@ function makeArgs(
       hash:
         'hash' in config.network.genesisBlock
           ? config.network.genesisBlock.hash
-          : undefined,
+          : undefined
     },
     storageDir: path.join(stateDir, 'chain'),
-    secretFile: _.map(config.network.secretFile || [], secret =>
+    secretFile: _.map(config.network.secretFile ?? [], secret =>
       path.join(config.configurationDir, secret)
     ),
-    extra: config.extraArgs,
-  };
+    extra: config.extraArgs
+  }
 }

--- a/src/jormungandr.ts
+++ b/src/jormungandr.ts
@@ -110,7 +110,7 @@ export async function startJormungandr (
   stateDir: DirPath,
   config: JormungandrConfig
 ): Promise<StartService> {
-  if (!config.restPort) {
+  if (config.restPort === undefined) {
     config.restPort = await getPort()
   }
   const args = makeArgs(stateDir, config)
@@ -128,11 +128,11 @@ export async function startJormungandr (
       // interleaved with the frontend logs.
       // "--log-format", "json",
     ]
-      .concat(args.restListen ? ['--rest-listen', args.restListen] : [])
+      .concat(args.restListen !== undefined ? ['--rest-listen', args.restListen] : [])
       .concat(
-        args.genesisBlock.file
+        args.genesisBlock.file !== undefined
           ? ['--genesis-block', args.genesisBlock.file]
-          : args.genesisBlock.hash
+          : args.genesisBlock.hash !== undefined
             ? ['--genesis-block-hash', args.genesisBlock.hash]
             : []
       )

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -35,9 +35,9 @@ export function prependName (logger: Logger, name: string): Logger {
     severity: 'debug' | 'info' | 'error',
     msg: string,
     param?: any
-  ) => {
+  ): void => {
     const prefixed = `${name}: ${msg}`
-    if (param) {
+    if (param !== undefined) {
       logger[severity](prefixed, param)
     } else {
       logger[severity](prefixed)

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -13,17 +13,15 @@
  * Logging adapter.
  */
 export interface Logger {
-  debug: LogFunc;
-  info: LogFunc;
-  error: LogFunc;
+  debug: LogFunc
+  info: LogFunc
+  error: LogFunc
 }
 
 /**
  * Function which logs a message and optional object.
  */
-export interface LogFunc {
-  (msg: string, param?: any): void;
-}
+export type LogFunc = (msg: string, param?: any) => void;
 
 /**
  * Create a new logger with a context name added.
@@ -32,22 +30,22 @@ export interface LogFunc {
  * @param name - context to prepend.
  * @return - a new logger.
  */
-export function prependName(logger: Logger, name: string): Logger {
+export function prependName (logger: Logger, name: string): Logger {
   const prefix = (
     severity: 'debug' | 'info' | 'error',
     msg: string,
     param?: any
   ) => {
-    const prefixed = `${name}: ${msg}`;
+    const prefixed = `${name}: ${msg}`
     if (param) {
-      logger[severity](prefixed, param);
+      logger[severity](prefixed, param)
     } else {
-      logger[severity](prefixed);
+      logger[severity](prefixed)
     }
-  };
+  }
   return {
     debug: (msg: string, param?: any) => prefix('debug', msg, param),
     info: (msg: string, param?: any) => prefix('info', msg, param),
-    error: (msg: string, param?: any) => prefix('error', msg, param),
-  };
+    error: (msg: string, param?: any) => prefix('error', msg, param)
+  }
 }

--- a/src/shelley.ts
+++ b/src/shelley.ts
@@ -1,6 +1,6 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
-
+/* eslint-disable */
 /**
  * Configuration for `cardano-node` (Shelley).
  *

--- a/src/shelley.ts
+++ b/src/shelley.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-import { StartService } from './service';
+import { StartService } from './service'
 
 /**
  * Configuration parameters for starting cardano-node (Shelley).
@@ -15,29 +15,29 @@ import { StartService } from './service';
  * Unimplemented!
  */
 export interface ShelleyNodeConfig {
-  kind: 'shelley';
+  kind: 'shelley'
 
   /**
    * Directory which will contain a socket file to use for communicating with the node.
    * Defaults to a subdirectory of the state directory.
    */
-  socketDir?: string;
+  socketDir?: string
 
   /**
    * Contents of the `cardano-node` config file.
    */
-  extraConfig?: { [propName: string]: any };
+  extraConfig?: { [propName: string]: any }
 
   /**
    * Extra arguments to add to the `cardano-node` command line.
    */
-  extraArgs?: string[];
+  extraArgs?: string[]
 }
 
-export async function startShelleyNode(
+export async function startShelleyNode (
   config: ShelleyNodeConfig
 ): Promise<StartService> {
-  throw new Error('shelley backend not implemented');
+  throw new Error('shelley backend not implemented')
   // return {
   //   command: "cardano-node", args: ["--help"]
   // };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,47 +1,47 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
-import * as tmp from 'tmp-promise';
-import path from 'path';
+import * as tmp from 'tmp-promise'
+import path from 'path'
 
-import { delay, expectProcessToBeGone, setupExecPath, withByronConfigDir } from './utils';
-import { fork } from 'child_process';
+import { delay, expectProcessToBeGone, setupExecPath, withByronConfigDir } from './utils'
+import { fork } from 'child_process'
 
 describe('CLI tests', () => {
   const killTest = (args: string[]) => async () => {
-    setupExecPath();
+    setupExecPath()
     const stateDir = (
       await tmp.dir({ unsafeCleanup: true, prefix: 'launcher-cli-test' })
-    ).path;
-    const proc = fork(path.resolve(__dirname, '..','dist', 'cli.js'), args.concat([stateDir]), {
+    ).path
+    const proc = fork(path.resolve(__dirname, '..', 'dist', 'cli.js'), args.concat([stateDir]), {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
-      env: process.env,
-    });
-    let nodePid: number | null = null;
-    let walletPid: number | null = null;
+      env: process.env
+    })
+    let nodePid: number | null = null
+    let walletPid: number | null = null
     proc.on('message', (message: any) => {
-      console.log('received message', message);
+      console.log('received message', message)
       if (message.node) {
-        nodePid = message.node;
+        nodePid = message.node
       }
       if (message.wallet) {
-        walletPid = message.wallet;
+        walletPid = message.wallet
       }
-    });
-    await delay(1000);
-    expect(nodePid).not.toBeNull();
-    expect(walletPid).not.toBeNull();
-    proc.kill();
-    await delay(1000);
-    expectProcessToBeGone(nodePid as any, 9);
-    expectProcessToBeGone(walletPid as any, 9);
-  };
+    })
+    await delay(1000)
+    expect(nodePid).not.toBeNull()
+    expect(walletPid).not.toBeNull()
+    proc.kill()
+    await delay(1000)
+    expectProcessToBeGone(nodePid as any, 9)
+    expectProcessToBeGone(walletPid as any, 9)
+  }
 
   it(
     'when the parent process is killed, child jormungandr gets stopped',
     killTest(['jormungandr', 'self', path.resolve(__dirname, 'data', 'jormungandr')])
-  );
+  )
 
   it('when the parent process is killed, cardano-node gets stopped', () =>
-    withByronConfigDir(configs => killTest(['byron', 'mainnet', configs])()));
-});
+    withByronConfigDir(configs => killTest(['byron', 'mainnet', configs])()))
+})

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,21 +1,21 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
-import { Launcher, LaunchConfig, ServiceStatus, Api } from '../src';
+import { Launcher, LaunchConfig, ServiceStatus, Api } from '../src'
 
-import * as http from 'http';
-import * as tmp from 'tmp-promise';
-import * as path from 'path';
+import * as http from 'http'
+import * as tmp from 'tmp-promise'
+import * as path from 'path'
 
-import * as jormungandr from '../src/jormungandr';
-import * as byron from '../src/byron';
-import { makeRequest, setupExecPath, withByronConfigDir } from './utils';
-import { createWriteStream } from 'fs';
-import { stat } from 'fs-extra';
-import { withFile, FileResult } from 'tmp-promise';
+import * as jormungandr from '../src/jormungandr'
+import * as byron from '../src/byron'
+import { makeRequest, setupExecPath, withByronConfigDir } from './utils'
+import { createWriteStream } from 'fs'
+import { stat } from 'fs-extra'
+import { withFile, FileResult } from 'tmp-promise'
 
 // increase time available for tests to run
-const longTestTimeoutMs = 15000;
+const longTestTimeoutMs = 15000
 
 describe('Starting cardano-wallet (and its node)', () => {
   const setupTestLauncher = async (
@@ -24,68 +24,68 @@ describe('Starting cardano-wallet (and its node)', () => {
     const stateDir = (
       await tmp.dir({
         unsafeCleanup: true,
-        prefix: 'launcher-integration-test',
+        prefix: 'launcher-integration-test'
       })
-    ).path;
-    const launcher = new Launcher(config(stateDir));
+    ).path
+    const launcher = new Launcher(config(stateDir))
 
     launcher.walletService.events.on(
       'statusChanged',
       (status: ServiceStatus) => {
-        console.log('wallet service status changed ' + ServiceStatus[status]);
+        console.log('wallet service status changed ' + ServiceStatus[status])
       }
-    );
+    )
 
     launcher.nodeService.events.on('statusChanged', (status: ServiceStatus) => {
-      console.log('node service status changed ' + ServiceStatus[status]);
-    });
+      console.log('node service status changed ' + ServiceStatus[status])
+    })
 
     launcher.walletBackend.events.on('ready', (api: Api) => {
-      console.log('ready event ', api);
-    });
-    return launcher;
-  };
+      console.log('ready event ', api)
+    })
+    return launcher
+  }
 
   const cleanupTestLauncher = (launcher: Launcher) => {
-    launcher.walletBackend.events.removeAllListeners();
-    launcher.walletService.events.removeAllListeners();
-    launcher.nodeService.events.removeAllListeners();
-  };
+    launcher.walletBackend.events.removeAllListeners()
+    launcher.walletService.events.removeAllListeners()
+    launcher.nodeService.events.removeAllListeners()
+  }
 
   const launcherTest = async (config: (stateDir: string) => LaunchConfig) => {
-    setupExecPath();
+    setupExecPath()
 
-    const launcher = await setupTestLauncher(config);
-    const api = await launcher.start();
-    const walletProc = launcher.walletService.getProcess();
-    const nodeProc = launcher.nodeService.getProcess();
+    const launcher = await setupTestLauncher(config)
+    const api = await launcher.start()
+    const walletProc = launcher.walletService.getProcess()
+    const nodeProc = launcher.nodeService.getProcess()
 
-    expect(walletProc).toHaveProperty('pid');
-    expect(nodeProc).toHaveProperty('pid');
+    expect(walletProc).toHaveProperty('pid')
+    expect(nodeProc).toHaveProperty('pid')
 
     const info: any = await new Promise((resolve, reject) => {
-      console.log('running req');
+      console.log('running req')
       const req = http.request(makeRequest(api, 'network/information'), res => {
-        res.setEncoding('utf8');
-        res.on('data', d => resolve(JSON.parse(d)));
-      });
+        res.setEncoding('utf8')
+        res.on('data', d => resolve(JSON.parse(d)))
+      })
       req.on('error', (e: any) => {
-        console.error(`problem with request: ${e.message}`);
-        reject(e);
-      });
-      req.end();
-    });
+        console.error(`problem with request: ${e.message}`)
+        reject(e)
+      })
+      req.end()
+    })
 
-    console.log('info is ', info);
+    console.log('info is ', info)
 
-    expect(info.node_tip).toBeTruthy();
+    expect(info.node_tip).toBeTruthy()
 
-    await launcher.stop(5);
+    await launcher.stop(5)
 
-    console.log('stopped');
+    console.log('stopped')
 
-    cleanupTestLauncher(launcher);
-  };
+    cleanupTestLauncher(launcher)
+  }
 
   it(
     'cardano-wallet-jormungandr responds to requests',
@@ -97,30 +97,30 @@ describe('Starting cardano-wallet (and its node)', () => {
           nodeConfig: {
             kind: 'jormungandr',
             configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
-            network: jormungandr.networks.self,
-          },
-        };
+            network: jormungandr.networks.self
+          }
+        }
       }),
     longTestTimeoutMs
-  );
+  )
   it(
     'cardano-wallet-byron responds to requests',
     () =>
       withByronConfigDir(configurationDir => {
-        return launcherTest(stateDir => {
+        return await launcherTest(stateDir => {
           return {
             stateDir,
             networkName: 'mainnet',
             nodeConfig: {
               kind: 'byron',
               configurationDir,
-              network: byron.networks.mainnet,
-            },
-          };
-        });
+              network: byron.networks.mainnet
+            }
+          }
+        })
       }),
     longTestTimeoutMs
-  );
+  )
 
   it('emits one and only one exit event', async () => {
     const launcher = await setupTestLauncher(stateDir => {
@@ -130,48 +130,48 @@ describe('Starting cardano-wallet (and its node)', () => {
         nodeConfig: {
           kind: 'jormungandr',
           configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
-          network: jormungandr.networks.self,
-        },
-      };
-    });
+          network: jormungandr.networks.self
+        }
+      }
+    })
 
-    const events = [];
-    launcher.walletBackend.events.on('exit', st => events.push(st));
+    const events = []
+    launcher.walletBackend.events.on('exit', st => events.push(st))
 
-    await launcher.start();
-    await Promise.all([launcher.stop(), launcher.stop(), launcher.stop()]);
-    await launcher.stop();
+    await launcher.start()
+    await Promise.all([launcher.stop(), launcher.stop(), launcher.stop()])
+    await launcher.stop()
 
-    expect(events.length).toBe(1);
+    expect(events.length).toBe(1)
 
-    cleanupTestLauncher(launcher);
-  });
+    cleanupTestLauncher(launcher)
+  })
 
   it('Accepts a WriteStream, and pipes the child process stdout and stderr streams', () =>
     withFile(async (logFile: FileResult) => {
       const childProcessLogWriteStream = createWriteStream(logFile.path, {
-        fd: logFile.fd,
-      });
+        fd: logFile.fd
+      })
       const launcher = new Launcher({
         stateDir: (
           await tmp.dir({
             unsafeCleanup: true,
-            prefix: 'launcher-integration-test-2',
+            prefix: 'launcher-integration-test-2'
           })
         ).path,
         networkName: 'self',
         nodeConfig: {
           kind: 'jormungandr',
           configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
-          network: jormungandr.networks.self,
+          network: jormungandr.networks.self
         },
-        childProcessLogWriteStream,
-      });
-      await launcher.start();
-      const logFileStats = await stat(logFile.path);
-      expect(logFileStats.size > 0);
-      await launcher.stop();
-    }));
+        childProcessLogWriteStream
+      })
+      await launcher.start()
+      const logFileStats = await stat(logFile.path)
+      expect(logFileStats.size > 0)
+      await launcher.stop()
+    }))
 
   it('handles case where node fails to start', async () => {
     const launcher = await setupTestLauncher(stateDir => {
@@ -182,17 +182,17 @@ describe('Starting cardano-wallet (and its node)', () => {
           kind: 'jormungandr',
           configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
           network: jormungandr.networks.self,
-          extraArgs: ['--yolo'], // not a jormungandr arg
-        },
-      };
-    });
+          extraArgs: ['--yolo'] // not a jormungandr arg
+        }
+      }
+    })
 
     await expect(launcher.start().finally(() => cleanupTestLauncher(launcher)))
       .rejects.toThrow(
         [
           'cardano-wallet-jormungandr exited with status 0',
-          'jormungandr exited with status 1',
+          'jormungandr exited with status 1'
         ].join('\n')
-      );
-  });
-});
+      )
+  })
+})

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,16 +1,16 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
-import { setupService, ServiceStatus, ServiceExitStatus } from '../src/service';
+import { setupService, ServiceStatus, ServiceExitStatus } from '../src/service'
 import {
   testService,
   collectEvents,
   expectProcessToBeGone,
-  mockLogger,
-} from './utils';
+  mockLogger
+} from './utils'
 
 // increase time available for some tests to run
-const longTestTimeoutMs = 15000;
+const longTestTimeoutMs = 15000
 
 // Note: These tests use simple coreutils commands as mock services.
 // For example, `cat` will read its standard input and exit on EOF.
@@ -18,140 +18,140 @@ const longTestTimeoutMs = 15000;
 
 describe('setupService', () => {
   it('starting simple command', async () => {
-    let service = setupService(testService('echo', ['test echo']));
-    let events: ServiceStatus[] = [];
-    service.events.on('statusChanged', status => events.push(status));
-    await service.start();
-    expect(service.getProcess()).toHaveProperty('pid');
-    return new Promise(done => {
+    const service = setupService(testService('echo', ['test echo']))
+    const events: ServiceStatus[] = []
+    service.events.on('statusChanged', status => events.push(status))
+    await service.start()
+    expect(service.getProcess()).toHaveProperty('pid')
+    return await new Promise(done => {
       service.events.on('statusChanged', status => {
         if (status === ServiceStatus.Stopped) {
           expect(events).toEqual([
             ServiceStatus.Starting,
             ServiceStatus.Started,
-            ServiceStatus.Stopped,
-          ]);
+            ServiceStatus.Stopped
+          ])
         }
-        done();
-      });
-    });
-  });
+        done()
+      })
+    })
+  })
 
   it('stopping a command', async () => {
-    let service = setupService(testService('cat', []));
-    let events: ServiceStatus[] = [];
-    service.events.on('statusChanged', status => events.push(status));
-    let pid = await service.start();
-    let result = await service.stop(2);
+    const service = setupService(testService('cat', []))
+    const events: ServiceStatus[] = []
+    service.events.on('statusChanged', status => events.push(status))
+    const pid = await service.start()
+    const result = await service.stop(2)
     // process should not exist
-    expect(() => process.kill(pid, 0)).toThrow();
+    expect(() => process.kill(pid, 0)).toThrow()
     // end of file for cat
-    expect(result).toEqual({ exe: 'cat', code: 0, signal: null, err: null });
-  });
+    expect(result).toEqual({ exe: 'cat', code: 0, signal: null, err: null })
+  })
 
   it('stopping a command (timeout)', async () => {
-    let service = setupService(testService('sleep', ['4']));
-    let pid = await service.start();
-    let result = await service.stop(2);
+    const service = setupService(testService('sleep', ['4']))
+    const pid = await service.start()
+    const result = await service.stop(2)
     // process should not exist
-    expect(() => process.kill(pid, 0)).toThrow();
+    expect(() => process.kill(pid, 0)).toThrow()
     // exited with signal
     expect(result).toEqual({
       exe: 'sleep',
       code: null,
       signal: 'SIGKILL',
-      err: null,
-    });
-  });
+      err: null
+    })
+  })
 
   it(
     'command was killed',
     () => {
-      const service = setupService(testService('sleep', ['10'], false));
-      const events: ServiceStatus[] = [];
-      service.events.on('statusChanged', status => events.push(status));
-      const pidP = service.start();
-      return new Promise(done => {
+      const service = setupService(testService('sleep', ['10'], false))
+      const events: ServiceStatus[] = []
+      service.events.on('statusChanged', status => events.push(status))
+      const pidP = service.start()
+      return await new Promise(done => {
         setTimeout(
           () =>
             pidP.then(pid => {
-              console.log('Killing the process ' + pid);
-              process.kill(pid);
+              console.log('Killing the process ' + pid)
+              process.kill(pid)
             }),
           1000
-        );
+        )
         service.events.on('statusChanged', status => {
           if (status === ServiceStatus.Stopped) {
             expect(events).toEqual([
               ServiceStatus.Starting,
               ServiceStatus.Started,
-              ServiceStatus.Stopped,
-            ]);
+              ServiceStatus.Stopped
+            ])
             service.stop().then((status: ServiceExitStatus) => {
               if (process.platform === 'win32') {
-                expect(status.code).toBe(1);
+                expect(status.code).toBe(1)
               } else {
-                expect(status.code).toBeNull();
-                expect(status.signal).toBe('SIGTERM');
+                expect(status.code).toBeNull()
+                expect(status.signal).toBe('SIGTERM')
               }
-              expect(status.exe).toBe('sleep');
-              done();
-            });
+              expect(status.exe).toBe('sleep')
+              done()
+            })
           }
-        });
-      });
+        })
+      })
     },
     longTestTimeoutMs
-  );
+  )
 
   it('start is idempotent', async () => {
-    let service = setupService(testService('cat', []));
-    let events = collectEvents(service);
-    let pid1 = await service.start();
-    let pid2 = await service.start();
-    await service.stop(2);
+    const service = setupService(testService('cat', []))
+    const events = collectEvents(service)
+    const pid1 = await service.start()
+    const pid2 = await service.start()
+    await service.stop(2)
     // should have only started once
-    expect(pid1).toBe(pid2);
+    expect(pid1).toBe(pid2)
     // process should not exist
-    expectProcessToBeGone(pid1);
+    expectProcessToBeGone(pid1)
     // events fire only once
     expect(events).toEqual([
       ServiceStatus.Starting,
       ServiceStatus.Started,
       ServiceStatus.Stopping,
-      ServiceStatus.Stopped,
-    ]);
-  });
+      ServiceStatus.Stopped
+    ])
+  })
 
   it('stop is idempotent', async () => {
-    let service = setupService(testService('cat', []));
-    let events = collectEvents(service);
-    let pid = await service.start();
-    let result1 = await service.stop(2);
-    let result2 = await service.stop(2);
+    const service = setupService(testService('cat', []))
+    const events = collectEvents(service)
+    const pid = await service.start()
+    const result1 = await service.stop(2)
+    const result2 = await service.stop(2)
     // same result
-    expect(result1).toEqual(result2);
+    expect(result1).toEqual(result2)
     // process should not exist
-    expectProcessToBeGone(pid);
+    expectProcessToBeGone(pid)
     // cat command exits normally
-    expect(result1).toEqual({ exe: 'cat', code: 0, signal: null, err: null });
+    expect(result1).toEqual({ exe: 'cat', code: 0, signal: null, err: null })
     // events fire only once
     expect(events).toEqual([
       ServiceStatus.Starting,
       ServiceStatus.Started,
       ServiceStatus.Stopping,
-      ServiceStatus.Stopped,
-    ]);
-  });
+      ServiceStatus.Stopped
+    ])
+  })
 
   it('stopping an already stopped command', done => {
-    let service = setupService(testService('echo', ['hello from tests']));
-    let events = collectEvents(service);
-    let pidP = service.start();
+    const service = setupService(testService('echo', ['hello from tests']))
+    const events = collectEvents(service)
+    const pidP = service.start()
     setTimeout(() => {
       // should have exited after 1 second
       pidP.then(pid => {
-        expectProcessToBeGone(pid);
+        expectProcessToBeGone(pid)
         // stop what's already stopped
         service.stop(2).then(result => {
           // check collected status
@@ -159,36 +159,36 @@ describe('setupService', () => {
             exe: 'echo',
             code: 0,
             signal: null,
-            err: null,
-          });
+            err: null
+          })
           // sequence of events doesn't include Stopping
           expect(events).toEqual([
             ServiceStatus.Starting,
             ServiceStatus.Started,
-            ServiceStatus.Stopped,
-          ]);
-          done();
-        });
-      });
-    }, 1000);
-  });
+            ServiceStatus.Stopped
+          ])
+          done()
+        })
+      })
+    }, 1000)
+  })
 
   it('starting a bogus command', async () => {
-    let logger = mockLogger(true);
-    let service = setupService(testService('xyzzy', []), logger);
-    let events = collectEvents(service);
-    await service.start();
-    let result = await service.waitForExit();
+    const logger = mockLogger(true)
+    const service = setupService(testService('xyzzy', []), logger)
+    const events = collectEvents(service)
+    await service.start()
+    const result = await service.waitForExit()
     expect(result.err ? result.err.toString() : null).toBe(
       'Error: spawn xyzzy ENOENT'
-    );
-    expect(result.code).toBeNull();
-    expect(result.signal).toBeNull();
+    )
+    expect(result.code).toBeNull()
+    expect(result.signal).toBeNull()
     expect(events).toEqual([
       ServiceStatus.Starting,
       ServiceStatus.Started,
-      ServiceStatus.Stopped,
-    ]);
-    expect(logger.getLogs().filter(l => l.severity === 'error').length).toBe(1);
-  });
-});
+      ServiceStatus.Stopped
+    ])
+    expect(logger.getLogs().filter(l => l.severity === 'error').length).toBe(1)
+  })
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -15,7 +15,7 @@ import { Logger, LogFunc } from '../src/logging'
  ******************************************************************************/
 
 /** Construct a promise to a service command. */
-export function testService (
+export async function testService (
   command: string,
   args: string[],
   supportsCleanShutdown = true
@@ -32,7 +32,7 @@ export const expectProcessToBeGone = (
   pid: number,
   signal: number = 0
 ): void => {
-  expect(() => process.kill(pid, signal)).toThrow()
+  return expect(() => process.kill(pid, signal)).toThrow()
 }
 
 /**
@@ -60,7 +60,7 @@ export function mockLogger (echo: boolean = false): MockLogger {
   const mockLog = (severity: 'debug' | 'info' | 'error'): LogFunc => {
     return (msg: string, param?: object) => {
       if (echo) {
-        if (param) {
+        if (param !== null) {
           console[severity](msg, param)
         } else {
           console[severity](msg)
@@ -78,7 +78,7 @@ export function mockLogger (echo: boolean = false): MockLogger {
   }
 }
 
-export function delay (ms: number) {
+export async function delay (ms: number): Promise<void> {
   return await new Promise(resolve => setTimeout(resolve, ms))
 }
 
@@ -110,7 +110,7 @@ export function makeRequest (api: Api, path: string, options?: object): object {
  * If the node backend is run in a different working directory,
  * Windows will still be able to find the executables
  */
-export function setupExecPath () {
+export function setupExecPath (): void {
   if (process.platform === 'win32') {
     const cwd = process.cwd()
     const paths = (process.env.PATH ?? '')
@@ -132,9 +132,9 @@ export function setupExecPath () {
  */
 export async function withByronConfigDir (
   cb: (configDir: string) => Promise<void>
-) {
+): Promise<void> {
   const base = process.env.BYRON_CONFIGS
-  if (!base) {
+  if (base === undefined) {
     const msg =
       'BYRON_CONFIGS environment variable is not set. The tests will not work.'
     console.error(msg)
@@ -162,7 +162,7 @@ export async function withByronConfigDir (
         'utf-8'
       )
       const configFixed = config
-        .replace(/configuration\//g, base + path.sep)
+        .replace(/configuration\//g, `${base}${path.sep}`)
         .replace(/^.*SocketPath.*$/gm, '')
       await fs.promises.writeFile(configs.configuration.dst, configFixed)
 


### PR DESCRIPTION
This PR shakes out the issues we're having with the test suite, by moving to a more strict set of lint rules being introducing for conformance with the preceding Adrestia JS project: Cardano GraphQL. 

There are two auto fix commits, one for each the [test](008dff7c4897210daddc37e4a3964142c45317d5) and [src](567183cf442b210193957971b64dec7a23756651). The important changes are in:
2863cc1dc7cd7a20299d419b6f48d7d9a96c575f
c179ce66c854182ed1a0394e2f1e2068c2b9c9c4