### PR TITLE
Fix floating promise which caused integration test failure on Windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,8 @@
       2,
       "unix"
     ],
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "@typescript-eslint/no-floating-promises": "warn"
   },
   "env": {
     "jest": true

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -27,7 +27,7 @@ import {
   setupService,
   serviceExitStatusMessage,
 } from './service';
-import { DirPath, catchFloatingPromise, ignorePromiseRejection } from './common';
+import { DirPath, passthroughErrorLogger, ignorePromiseRejection } from './common';
 
 import * as byron from './byron';
 import * as shelley from './shelley';
@@ -198,19 +198,19 @@ export class Launcher {
       .then((startService: WalletStartService) => {
         this.apiPort = startService.apiPort;
       })
-      .catch(catchFloatingPromise);
+      .catch(passthroughErrorLogger);
 
     this.walletService.events.on('statusChanged', status => {
       if (status === ServiceStatus.Stopped) {
         this.logger.debug('wallet exited');
-        this.stop().catch(catchFloatingPromise);
+        this.stop().catch(passthroughErrorLogger);
       }
     });
 
     this.nodeService.events.on('statusChanged', status => {
       if (status === ServiceStatus.Stopped) {
         this.logger.debug('node exited');
-        this.stop().catch(catchFloatingPromise);
+        this.stop().catch(passthroughErrorLogger);
       }
     });
 
@@ -330,8 +330,8 @@ export class Launcher {
     signals.forEach((signal: Signals) =>
       process.on(signal, () => {
         this.logger.info(`Received ${signal} - stopping services...`);
-        this.walletService.stop(0).catch(catchFloatingPromise);
-        this.nodeService.stop(0).catch(catchFloatingPromise);
+        this.walletService.stop(0).catch(passthroughErrorLogger);
+        this.nodeService.stop(0).catch(passthroughErrorLogger);
       })
     );
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
   ExitStatus
 } from './cardanoLauncher';
 
+import { ignorePromiseRejection } from './common';
 import {
   ServiceExitStatus,
   serviceExitStatusMessage,
@@ -79,11 +80,11 @@ export function cli(argv: Process['argv']) {
 
   const launcher = new Launcher({stateDir, nodeConfig, networkName}, console);
 
-  launcher.start();
+  launcher.start().catch(ignorePromiseRejection);
 
   // inform tests of subprocess pids
-  launcher.nodeService.start().then(pid => sendMaybe({node: pid}));
-  launcher.walletService.start().then(pid => sendMaybe({wallet: pid}));
+  launcher.nodeService.start().then(pid => sendMaybe({node: pid})).catch(ignorePromiseRejection);
+  launcher.walletService.start().then(pid => sendMaybe({wallet: pid})).catch(ignorePromiseRejection);
 
   launcher.walletBackend.events.on('exit', (status: ExitStatus) => {
     console.log(serviceExitStatusMessage(status.wallet));

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,3 +11,21 @@
 export type FilePath = string;
 /** Type alias to indicate the path of a directory. */
 export type DirPath = string;
+
+/**
+ * Use this with `.catch()` on promises where the error is already
+ * handled elsewhere, but where you would like to debug log the
+ * condition.
+ */
+export function catchFloatingPromise(err: Error) {
+  console.debug("Caught an unhandled promise " + (new Error()).stack);
+  console.debug(err);
+}
+
+/**
+ * Use this with `.catch()` on promises where the error is already
+ * handled elsewhere. This handler does nothing except prevent an
+ * eslint warning from appearing.
+ */
+export function ignorePromiseRejection(_: Error) {
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,12 +13,14 @@ export type FilePath = string;
 export type DirPath = string;
 
 /**
- * Use this with `.catch()` on promises where the error is already
- * handled elsewhere, but where you would like to debug log the
- * condition.
+ * Use this with `.catch()` on promises where the error condition is
+ * already handled elsewhere (e.g. by an event or another promise).
+ *
+ * It will debug log the `Error` and a stack trace of the "floating
+ * promise".
  */
-export function catchFloatingPromise(err: Error) {
-  console.debug("Caught an unhandled promise " + (new Error()).stack);
+export function passthroughErrorLogger(err: Error) {
+  console.debug("Caught an unhandled promise rejection. The promise location is:\n" + (new Error()).stack + "\n\nThe error follows:");
   console.debug(err);
 }
 


### PR DESCRIPTION
When running:
    
    npm test -- integration -t "node fails to start"

It showed these warnings after passing the test:

    (node:9036) UnhandledPromiseRejectionWarning: undefined
    (node:9036) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
    (node:9036) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

The warnings appeared on both Linux (node v10.17.0) and Windows 10 (node v13.11.0). It failed outright on GitHub Windows CI.

The reason was that when the `waitForApi()` loop was cancelled it would reject the promise, ahd that was not caught.

The fix is to not use promises for `waitForApi()`.

This also quashes all eslint warnings for `no-floating-promises`.

Thanks @SebastienGllmt for suggesting the eslint `no-floating-promises` rule and @rhyslbw for identifying the source of the `undefined` exception.
