### PR TITLE
Enable more recommended eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,14 +8,12 @@ module.exports = {
   extends: [
     'prettier/@typescript-eslint',
     'plugin:prettier/recommended', // format sources with prettier.io
-
-    // Enabling the following may be helpful...
     // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-    // "plugin:@typescript-eslint/recommended",
+    'plugin:@typescript-eslint/recommended',
     // Recommended by https://www.npmjs.com/package/eslint-plugin-jest
-    // "plugin:jest/recommended",
+    'plugin:jest/recommended',
     // Optional pedantic stuff
-    // "plugin:jest/style",
+    'plugin:jest/style',
   ],
   plugins: [
     "@typescript-eslint",

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -46,6 +46,84 @@ export {
   Service,
 } from './service';
 
+/*******************************************************************************
+ * Api
+ ******************************************************************************/
+
+interface RequestParams {
+  port: number;
+  path: string;
+  hostname: string;
+}
+
+/**
+ * Connection parameters for the `cardano-wallet` API.
+ * These should be used to build the HTTP requests.
+ */
+export interface Api {
+  /**
+   * API base URL, including trailling slash.
+   */
+  baseUrl: string;
+
+  /**
+   * URL components which can be used with the HTTP client library of
+   * your choice.
+   */
+  requestParams: RequestParams;
+}
+
+class V2Api implements Api {
+  /** URL of the API, including a trailling slash. */
+  readonly baseUrl: string;
+  /** URL components which can be used with the HTTP client library of
+   * your choice. */
+  readonly requestParams: RequestParams;
+
+  constructor(port: number) {
+    const hostname = '127.0.0.1';
+    const path = '/v2/';
+    this.baseUrl = `http://${hostname}:${port}${path}`;
+    this.requestParams = { port, path, hostname };
+  }
+}
+
+/*******************************************************************************
+ * Exit status types
+ ******************************************************************************/
+
+/**
+ * The result after the launched wallet backend has finished.
+ */
+export interface ExitStatus {
+  wallet: ServiceExitStatus;
+  node: ServiceExitStatus;
+}
+
+/**
+ * Format an [[ExitStatus]] as a multiline human-readable string.
+ */
+export function exitStatusMessage(status: ExitStatus): string {
+  return _.map(status, serviceExitStatusMessage).join('\n');
+}
+
+/**
+ * This instance of [[Error]] will be returned when the
+ * `Launcher.start()` promise is rejected.
+ */
+export class BackendExitedError extends Error {
+  status: ExitStatus;
+  constructor(status: ExitStatus) {
+    super(exitStatusMessage(status));
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.status = status;
+  }
+}
+
+/*******************************************************************************
+ * Launching
+ ******************************************************************************/
+
 /**
  * Configuration parameters for starting the wallet backend and node.
  */
@@ -115,7 +193,7 @@ export interface LaunchConfig {
    *  behaviour interferes with your application shutdown behaviour.
    *  If setting this to false, ensure stop(0) is called as part of the shutdown.
    */
-  installSignalHandlers?: Boolean;
+  installSignalHandlers?: boolean;
 }
 
 /**
@@ -178,7 +256,7 @@ export class Launcher {
     const { childProcessLogWriteStream, installSignalHandlers = true } = config;
     this.logger = logger;
 
-    const start = makeServiceCommands(config, logger);
+    const start = Launcher.makeServiceCommands(config, logger);
     this.walletService = setupService(
       start.wallet,
       prependName(logger, 'wallet'),
@@ -191,7 +269,7 @@ export class Launcher {
     );
 
     this.walletBackend = {
-      getApi: () => new V2Api(this.apiPort),
+      getApi: (): V2Api => new V2Api(this.apiPort),
       events: new EventEmitter<{
         ready: (api: Api) => void;
         exit: (status: ExitStatus) => void;
@@ -236,7 +314,7 @@ export class Launcher {
    * server is ready to accept requests.
    */
   start(): Promise<Api> {
-    const stopWaiting = () =>
+    const stopWaiting = (): boolean =>
       this.nodeService.getStatus() > ServiceStatus.Started ||
       this.walletService.getStatus() > ServiceStatus.Started;
 
@@ -268,8 +346,8 @@ export class Launcher {
     this.logger.debug('waitForApi');
 
     let addr: net.SocketConnectOpts;
-    var client: net.Socket;
-    const poll = () => {
+    let client: net.Socket;
+    const timer = setInterval(() => {
       if (stop()) {
         clearInterval(timer);
       } else if (this.apiPort) {
@@ -293,8 +371,7 @@ export class Launcher {
           this.logger.debug(`waitForApi: not ready yet: ${err}`);
         });
       }
-    };
-    const timer = setInterval(poll, 250);
+    }, 250);
   }
 
   /**
@@ -339,72 +416,104 @@ export class Launcher {
       })
     );
   }
-}
 
-interface RequestParams {
-  port: number;
-  path: string;
-  hostname: string;
-}
-
-/**
- * Connection parameters for the `cardano-wallet` API.
- * These should be used to build the HTTP requests.
- */
-export interface Api {
-  /**
-   * API base URL, including trailling slash.
-   */
-  baseUrl: string;
-
-  /**
-   * URL components which can be used with the HTTP client library of
-   * your choice.
-   */
-  requestParams: RequestParams;
-}
-
-class V2Api implements Api {
-  /** URL of the API, including a trailling slash. */
-  readonly baseUrl: string;
-  /** URL components which can be used with the HTTP client library of
-   * your choice. */
-  readonly requestParams: RequestParams;
-
-  constructor(port: number) {
-    let hostname = '127.0.0.1';
-    let path = '/v2/';
-    this.baseUrl = `http://${hostname}:${port}${path}`;
-    this.requestParams = { port, path, hostname };
+  private static makeServiceCommands(
+    config: LaunchConfig,
+    logger: Logger
+  ): { wallet: Promise<WalletStartService>; node: Promise<StartService> } {
+    logger.info(
+      `Creating state directory ${config.stateDir} (if it doesn't already exist)`
+    );
+    const node = mkdirp(config.stateDir).then(() =>
+      Launcher.nodeExe(config.stateDir, config)
+    );
+    const wallet = node.then(nodeService =>
+      Launcher.walletExe(config.stateDir, config, nodeService)
+    );
+    return { wallet, node };
   }
-}
 
-/**
- * The result after the launched wallet backend has finished.
- */
-export interface ExitStatus {
-  wallet: ServiceExitStatus;
-  node: ServiceExitStatus;
-}
+  private static async walletExe(
+    baseDir: DirPath,
+    config: LaunchConfig,
+    _: StartService
+  ): Promise<WalletStartService> {
+    const apiPort = config.apiPort || (await getPort());
+    const base: WalletStartService = {
+      command: `cardano-wallet-${config.nodeConfig.kind}`,
+      args: [
+        'serve',
+        '--shutdown-handler',
+        '--port',
+        '' + apiPort,
+        '--database',
+        path.join(baseDir, 'wallets'),
+      ].concat(
+        config.listenAddress ? ['--listen-address', config.listenAddress] : [],
+        config.syncToleranceSeconds
+          ? ['--sync-tolerance', `${config.syncToleranceSeconds}s`]
+          : []
+      ),
+      extraEnv: config.stakePoolRegistryUrl
+        ? {
+            CARDANO_WALLET_STAKE_POOL_REGISTRY_URL: config.stakePoolRegistryUrl,
+          }
+        : undefined,
+      supportsCleanShutdown: true,
+      apiPort,
+    };
+    const addArgs = (args: string[]): WalletStartService =>
+      _.assign(base, { args: base.args.concat(args) });
 
-/**
- * This instance of [[Error]] will be returned when the
- * `Launcher.start()` promise is rejected.
- */
-export class BackendExitedError extends Error {
-  status: ExitStatus;
-  constructor(status: ExitStatus) {
-    super(exitStatusMessage(status));
-    Object.setPrototypeOf(this, new.target.prototype);
-    this.status = status;
+    switch (config.nodeConfig.kind) {
+      case 'jormungandr':
+        return addArgs([
+          '--genesis-block-hash',
+          config.nodeConfig.network.genesisBlock.hash,
+          '--node-port',
+          '' + config.nodeConfig.restPort,
+        ]);
+      case 'byron':
+        if (
+          config.networkName !== 'mainnet' &&
+          !config.nodeConfig.network.genesisFile
+        ) {
+          throw new Error('ByronNetwork.genesisFile must be configured');
+        }
+        const networkArg =
+          config.networkName === 'mainnet'
+            ? ['--mainnet']
+            : ['--testnet', '' + config.nodeConfig.network.genesisFile];
+
+        return addArgs(
+          networkArg.concat(
+            config.nodeConfig.socketFile
+              ? ['--node-socket', config.nodeConfig.socketFile]
+              : []
+          )
+        );
+      case 'shelley':
+        return base;
+    }
   }
-}
 
-/**
- * Format an [[ExitStatus]] as a multiline human-readable string.
- */
-export function exitStatusMessage(status: ExitStatus): string {
-  return _.map(status, serviceExitStatusMessage).join('\n');
+  private static nodeExe(
+    baseDir: DirPath,
+    config: LaunchConfig
+  ): Promise<StartService> {
+    switch (config.nodeConfig.kind) {
+      case 'jormungandr':
+        return jormungandr.startJormungandr(baseDir, config.nodeConfig);
+      case 'byron':
+        return byron.startByronNode(
+          baseDir,
+          config.nodeConfig,
+          config.networkName
+        );
+      case 'shelley':
+        return shelley.startShelleyNode(config.nodeConfig);
+    }
+  }
 }
 
 /**
@@ -446,100 +555,4 @@ type WalletBackendEvents = EventEmitter<{
 
 interface WalletStartService extends StartService {
   apiPort: number;
-}
-
-function makeServiceCommands(
-  config: LaunchConfig,
-  logger: Logger
-): { wallet: Promise<WalletStartService>; node: Promise<StartService> } {
-  logger.info(
-    `Creating state directory ${config.stateDir} (if it doesn't already exist)`
-  );
-  const node = mkdirp(config.stateDir).then(() =>
-    nodeExe(config.stateDir, config)
-  );
-  const wallet = node.then(nodeService =>
-    walletExe(config.stateDir, config, nodeService)
-  );
-  return { wallet, node };
-}
-
-async function walletExe(
-  baseDir: DirPath,
-  config: LaunchConfig,
-  node: StartService
-): Promise<WalletStartService> {
-  const apiPort = config.apiPort || (await getPort());
-  const base: WalletStartService = {
-    command: `cardano-wallet-${config.nodeConfig.kind}`,
-    args: [
-      'serve',
-      '--shutdown-handler',
-      '--port',
-      '' + apiPort,
-      '--database',
-      path.join(baseDir, 'wallets'),
-    ].concat(
-      config.listenAddress ? ['--listen-address', config.listenAddress] : [],
-      config.syncToleranceSeconds
-        ? ['--sync-tolerance', `${config.syncToleranceSeconds}s`]
-        : []
-    ),
-    extraEnv: config.stakePoolRegistryUrl
-      ? { CARDANO_WALLET_STAKE_POOL_REGISTRY_URL: config.stakePoolRegistryUrl }
-      : undefined,
-    supportsCleanShutdown: true,
-    apiPort,
-  };
-  const addArgs = (args: string[]): WalletStartService =>
-    _.assign(base, { args: base.args.concat(args) });
-
-  switch (config.nodeConfig.kind) {
-    case 'jormungandr':
-      return addArgs([
-        '--genesis-block-hash',
-        config.nodeConfig.network.genesisBlock.hash,
-        '--node-port',
-        '' + config.nodeConfig.restPort,
-      ]);
-    case 'byron':
-      if (
-        config.networkName !== 'mainnet' &&
-        !config.nodeConfig.network.genesisFile
-      ) {
-        throw new Error('ByronNetwork.genesisFile must be configured');
-      }
-      const networkArg =
-        config.networkName === 'mainnet'
-          ? ['--mainnet']
-          : ['--testnet', '' + config.nodeConfig.network.genesisFile];
-
-      return addArgs(
-        networkArg.concat(
-          config.nodeConfig.socketFile
-            ? ['--node-socket', config.nodeConfig.socketFile]
-            : []
-        )
-      );
-    case 'shelley':
-      return base;
-  }
-}
-
-function nodeExe(
-  baseDir: DirPath,
-  config: LaunchConfig
-): Promise<StartService> {
-  switch (config.nodeConfig.kind) {
-    case 'jormungandr':
-      return jormungandr.startJormungandr(baseDir, config.nodeConfig);
-    case 'byron':
-      return byron.startByronNode(
-        baseDir,
-        config.nodeConfig,
-        config.networkName
-      );
-    case 'shelley':
-      return shelley.startShelleyNode(config.nodeConfig);
-  }
 }

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -428,15 +428,14 @@ export class Launcher {
       Launcher.nodeExe(config.stateDir, config)
     );
     const wallet = node.then(nodeService =>
-      Launcher.walletExe(config.stateDir, config, nodeService)
+      Launcher.walletExe(config.stateDir, config)
     );
     return { wallet, node };
   }
 
   private static async walletExe(
     baseDir: DirPath,
-    config: LaunchConfig,
-    _: StartService
+    config: LaunchConfig
   ): Promise<WalletStartService> {
     const apiPort = config.apiPort || (await getPort());
     const base: WalletStartService = {

--- a/src/common.ts
+++ b/src/common.ts
@@ -19,7 +19,7 @@ export type DirPath = string;
  * It will debug log the `Error` and a stack trace of the "floating
  * promise".
  */
-export function passthroughErrorLogger(err: Error) {
+export function passthroughErrorLogger(err: Error): void {
   console.debug(
     'Caught an unhandled promise rejection. The promise location is:\n' +
       new Error().stack +
@@ -33,4 +33,4 @@ export function passthroughErrorLogger(err: Error) {
  * handled elsewhere. This handler does nothing except prevent an
  * eslint warning from appearing.
  */
-export function ignorePromiseRejection(_: Error) {}
+export function ignorePromiseRejection(_: Error): void {} // eslint-disable-line

--- a/src/jormungandr.ts
+++ b/src/jormungandr.ts
@@ -24,6 +24,7 @@ import { FilePath, DirPath } from './common';
  *
  */
 export const networks: { [propName: string]: JormungandrNetwork } = {
+  // eslint-disable-next-line @typescript-eslint/camelcase
   itn_rewards_v1: {
     configFile: 'itn_rewards_v1-config.yaml',
     genesisBlock: {
@@ -106,6 +107,32 @@ export interface JormungandrArgs {
    */
   extra?: string[];
 }
+
+function makeArgs(
+  stateDir: DirPath,
+  config: JormungandrConfig
+): JormungandrArgs {
+  return {
+    configFile: path.join(config.configurationDir, config.network.configFile),
+    restListen: `127.0.0.1:${config.restPort || 0}`,
+    genesisBlock: {
+      file:
+        'file' in config.network.genesisBlock
+          ? path.join(config.configurationDir, config.network.genesisBlock.file)
+          : undefined,
+      hash:
+        'hash' in config.network.genesisBlock
+          ? config.network.genesisBlock.hash
+          : undefined,
+    },
+    storageDir: path.join(stateDir, 'chain'),
+    secretFile: _.map(config.network.secretFile || [], secret =>
+      path.join(config.configurationDir, secret)
+    ),
+    extra: config.extraArgs,
+  };
+}
+
 export async function startJormungandr(
   stateDir: DirPath,
   config: JormungandrConfig
@@ -139,30 +166,5 @@ export async function startJormungandr(
       .concat(_.flatMap(args.secretFile || [], secret => ['--secret', secret]))
       .concat(args.extra || []),
     supportsCleanShutdown: false,
-  };
-}
-
-function makeArgs(
-  stateDir: DirPath,
-  config: JormungandrConfig
-): JormungandrArgs {
-  return {
-    configFile: path.join(config.configurationDir, config.network.configFile),
-    restListen: `127.0.0.1:${config.restPort || 0}`,
-    genesisBlock: {
-      file:
-        'file' in config.network.genesisBlock
-          ? path.join(config.configurationDir, config.network.genesisBlock.file)
-          : undefined,
-      hash:
-        'hash' in config.network.genesisBlock
-          ? config.network.genesisBlock.hash
-          : undefined,
-    },
-    storageDir: path.join(stateDir, 'chain'),
-    secretFile: _.map(config.network.secretFile || [], secret =>
-      path.join(config.configurationDir, secret)
-    ),
-    extra: config.extraArgs,
   };
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,8 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  * Cheap and cheerful logging functions.
  * Same as what is already in Daedalus.
@@ -37,7 +39,7 @@ export function prependName(logger: Logger, name: string): Logger {
     severity: 'debug' | 'info' | 'error',
     msg: string,
     param?: any
-  ) => {
+  ): void => {
     const prefixed = `${name}: ${msg}`;
     if (param) {
       logger[severity](prefixed, param);
@@ -46,8 +48,8 @@ export function prependName(logger: Logger, name: string): Logger {
     }
   };
   return {
-    debug: (msg: string, param?: any) => prefix('debug', msg, param),
-    info: (msg: string, param?: any) => prefix('info', msg, param),
-    error: (msg: string, param?: any) => prefix('error', msg, param),
+    debug: (msg: string, param?: any): void => prefix('debug', msg, param),
+    info: (msg: string, param?: any): void => prefix('info', msg, param),
+    error: (msg: string, param?: any): void => prefix('error', msg, param),
   };
 }

--- a/src/shelley.ts
+++ b/src/shelley.ts
@@ -1,6 +1,8 @@
 // Copyright © 2020 IOHK
 // License: Apache-2.0
 
+/* eslint-disable */
+
 /**
  * Configuration for `cardano-node` (Shelley).
  *

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -11,6 +11,8 @@
  * @packageDocumentation
  */
 
+/* eslint-disable jest/expect-expect */
+
 import * as tmp from 'tmp-promise';
 import path from 'path';
 
@@ -22,8 +24,13 @@ import {
 } from './utils';
 import { fork } from 'child_process';
 
+type Message = {
+  node?: number;
+  wallet?: number;
+};
+
 describe('CLI tests', () => {
-  const killTest = (args: string[]) => async () => {
+  const killTest = (args: string[]) => async (): Promise<void> => {
     setupExecPath();
     const stateDir = (
       await tmp.dir({ unsafeCleanup: true, prefix: 'launcher-cli-test' })
@@ -38,7 +45,7 @@ describe('CLI tests', () => {
     );
     let nodePid: number | null = null;
     let walletPid: number | null = null;
-    proc.on('message', (message: any) => {
+    proc.on('message', (message: Message) => {
       console.log('received message', message);
       if (message.node) {
         nodePid = message.node;
@@ -52,8 +59,8 @@ describe('CLI tests', () => {
     expect(walletPid).not.toBeNull();
     proc.kill();
     await delay(1000);
-    expectProcessToBeGone(nodePid as any, 9);
-    expectProcessToBeGone(walletPid as any, 9);
+    expectProcessToBeGone(nodePid as number, 9);
+    expectProcessToBeGone(walletPid as number, 9);
   };
 
   it(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -59,8 +59,12 @@ describe('CLI tests', () => {
     expect(walletPid).not.toBeNull();
     proc.kill();
     await delay(1000);
-    expectProcessToBeGone(nodePid as number, 9);
-    expectProcessToBeGone(walletPid as number, 9);
+    if (nodePid) {
+      expectProcessToBeGone(nodePid, 9);
+    }
+    if (walletPid) {
+      expectProcessToBeGone(walletPid, 9);
+    }
   };
 
   it(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -6,13 +6,14 @@ import { Launcher, LaunchConfig, ServiceStatus, Api } from '../src';
 import * as http from 'http';
 import * as tmp from 'tmp-promise';
 import * as path from 'path';
-
-import * as jormungandr from '../src/jormungandr';
-import * as byron from '../src/byron';
-import { makeRequest, setupExecPath, withByronConfigDir } from './utils';
 import { createWriteStream } from 'fs';
 import { stat } from 'fs-extra';
 import { withFile, FileResult } from 'tmp-promise';
+
+import * as jormungandr from '../src/jormungandr';
+import * as byron from '../src/byron';
+import { ExitStatus } from '../src/cardanoLauncher';
+import { makeRequest, setupExecPath, withByronConfigDir } from './utils';
 
 // increase time available for tests to run
 const longTestTimeoutMs = 15000;
@@ -141,7 +142,7 @@ describe('Starting cardano-wallet (and its node)', () => {
       };
     });
 
-    const events = [];
+    const events: ExitStatus[] = [];
     launcher.walletBackend.events.on('exit', st => events.push(st));
 
     await launcher.start();

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -18,8 +18,8 @@ const longTestTimeoutMs = 15000;
 
 describe('setupService', () => {
   it('starting simple command', async () => {
-    let service = setupService(testService('echo', ['test echo']));
-    let events: ServiceStatus[] = [];
+    const service = setupService(testService('echo', ['test echo']));
+    const events: ServiceStatus[] = [];
     service.events.on('statusChanged', status => events.push(status));
     await service.start();
     expect(service.getProcess()).toHaveProperty('pid');
@@ -38,11 +38,11 @@ describe('setupService', () => {
   });
 
   it('stopping a command', async () => {
-    let service = setupService(testService('cat', []));
-    let events: ServiceStatus[] = [];
+    const service = setupService(testService('cat', []));
+    const events: ServiceStatus[] = [];
     service.events.on('statusChanged', status => events.push(status));
-    let pid = await service.start();
-    let result = await service.stop(2);
+    const pid = await service.start();
+    const result = await service.stop(2);
     // process should not exist
     expect(() => process.kill(pid, 0)).toThrow();
     // end of file for cat
@@ -50,9 +50,9 @@ describe('setupService', () => {
   });
 
   it('stopping a command (timeout)', async () => {
-    let service = setupService(testService('sleep', ['4']));
-    let pid = await service.start();
-    let result = await service.stop(2);
+    const service = setupService(testService('sleep', ['4']));
+    const pid = await service.start();
+    const result = await service.stop(2);
     // process should not exist
     expect(() => process.kill(pid, 0)).toThrow();
     // exited with signal
@@ -108,10 +108,10 @@ describe('setupService', () => {
   );
 
   it('start is idempotent', async () => {
-    let service = setupService(testService('cat', []));
-    let events = collectEvents(service);
-    let pid1 = await service.start();
-    let pid2 = await service.start();
+    const service = setupService(testService('cat', []));
+    const events = collectEvents(service);
+    const pid1 = await service.start();
+    const pid2 = await service.start();
     await service.stop(2);
     // should have only started once
     expect(pid1).toBe(pid2);
@@ -127,11 +127,11 @@ describe('setupService', () => {
   });
 
   it('stop is idempotent', async () => {
-    let service = setupService(testService('cat', []));
-    let events = collectEvents(service);
-    let pid = await service.start();
-    let result1 = await service.stop(2);
-    let result2 = await service.stop(2);
+    const service = setupService(testService('cat', []));
+    const events = collectEvents(service);
+    const pid = await service.start();
+    const result1 = await service.stop(2);
+    const result2 = await service.stop(2);
     // same result
     expect(result1).toEqual(result2);
     // process should not exist
@@ -147,46 +147,48 @@ describe('setupService', () => {
     ]);
   });
 
-  it('stopping an already stopped command', done => {
-    let service = setupService(testService('echo', ['hello from tests']));
-    let events = collectEvents(service);
-    let pidP = service.start();
-    setTimeout(() => {
-      // should have exited after 1 second
-      pidP
-        .then(pid => {
-          expectProcessToBeGone(pid);
-          // stop what's already stopped
-          service
-            .stop(2)
-            .then(result => {
-              // check collected status
-              expect(result).toEqual({
-                exe: 'echo',
-                code: 0,
-                signal: null,
-                err: null,
-              });
-              // sequence of events doesn't include Stopping
-              expect(events).toEqual([
-                ServiceStatus.Starting,
-                ServiceStatus.Started,
-                ServiceStatus.Stopped,
-              ]);
-              done();
-            })
-            .catch(e => done.fail(e));
-        })
-        .catch(e => done.fail(e));
-    }, 1000);
+  it('stopping an already stopped command', () => {
+    return new Promise(done => {
+      const service = setupService(testService('echo', ['hello from tests']));
+      const events = collectEvents(service);
+      const pidP = service.start();
+      setTimeout(() => {
+        // should have exited after 1 second
+        pidP
+          .then(pid => {
+            expectProcessToBeGone(pid);
+            // stop what's already stopped
+            service
+              .stop(2)
+              .then(result => {
+                // check collected status
+                expect(result).toEqual({
+                  exe: 'echo',
+                  code: 0,
+                  signal: null,
+                  err: null,
+                });
+                // sequence of events doesn't include Stopping
+                expect(events).toEqual([
+                  ServiceStatus.Starting,
+                  ServiceStatus.Started,
+                  ServiceStatus.Stopped,
+                ]);
+                done();
+              })
+              .catch(e => done.fail(e));
+          })
+          .catch(e => done.fail(e));
+      }, 1000);
+    });
   });
 
   it('starting a bogus command', async () => {
-    let logger = mockLogger(true);
-    let service = setupService(testService('xyzzy', []), logger);
-    let events = collectEvents(service);
+    const logger = mockLogger(true);
+    const service = setupService(testService('xyzzy', []), logger);
+    const events = collectEvents(service);
     await service.start();
-    let result = await service.waitForExit();
+    const result = await service.waitForExit();
     expect(result.err ? result.err.toString() : null).toBe(
       'Error: spawn xyzzy ENOENT'
     );
@@ -197,6 +199,8 @@ describe('setupService', () => {
       ServiceStatus.Started,
       ServiceStatus.Stopped,
     ]);
-    expect(logger.getLogs().filter(l => l.severity === 'error').length).toBe(1);
+    expect(logger.getLogs().filter(l => l.severity === 'error')).toHaveLength(
+      1
+    );
   });
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -148,7 +148,7 @@ describe('setupService', () => {
   });
 
   it('stopping an already stopped command', () => {
-    return new Promise(done => {
+    return new Promise((resolve, reject) => {
       const service = setupService(testService('echo', ['hello from tests']));
       const events = collectEvents(service);
       const pidP = service.start();
@@ -174,11 +174,11 @@ describe('setupService', () => {
                   ServiceStatus.Started,
                   ServiceStatus.Stopped,
                 ]);
-                done();
+                resolve();
               })
-              .catch(e => done.fail(e));
+              .catch(reject);
           })
-          .catch(e => done.fail(e));
+          .catch(reject);
       }, 1000);
     });
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -28,10 +28,7 @@ export function testService(
 /**
  * Expect the given process ID to not exist.
  */
-export const expectProcessToBeGone = (
-  pid: number,
-  signal: number = 0
-): void => {
+export const expectProcessToBeGone = (pid: number, signal = 0): void => {
   expect(() => process.kill(pid, signal)).toThrow();
 };
 
@@ -39,7 +36,7 @@ export const expectProcessToBeGone = (
  * @return mutable array which will contain events as they occur.
  */
 export const collectEvents = (service: Service): ServiceStatus[] => {
-  let events: ServiceStatus[] = [];
+  const events: ServiceStatus[] = [];
   service.events.on('statusChanged', status => events.push(status));
   return events;
 };
@@ -54,11 +51,11 @@ export interface MockLogger extends Logger {
   getLogs(): MockLog[];
 }
 
-export function mockLogger(echo: boolean = false): MockLogger {
-  let logs: MockLog[] = [];
+export function mockLogger(echo = false): MockLogger {
+  const logs: MockLog[] = [];
 
   const mockLog = (severity: 'debug' | 'info' | 'error'): LogFunc => {
-    return (msg: string, param?: object) => {
+    return (msg: string, param?: object): void => {
       if (echo) {
         if (param) {
           console[severity](msg, param);
@@ -74,11 +71,11 @@ export function mockLogger(echo: boolean = false): MockLogger {
     debug: mockLog('debug'),
     info: mockLog('info'),
     error: mockLog('error'),
-    getLogs: () => logs,
+    getLogs: (): MockLog[] => logs,
   };
 }
 
-export function delay(ms: number) {
+export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
@@ -110,7 +107,7 @@ export function makeRequest(api: Api, path: string, options?: object): object {
  * If the node backend is run in a different working directory,
  * Windows will still be able to find the executables
  */
-export function setupExecPath() {
+export function setupExecPath(): void {
   if (process.platform === 'win32') {
     const cwd = process.cwd();
     const paths = (process.env.PATH || '')
@@ -130,9 +127,9 @@ export function setupExecPath() {
  * are resolved relative to the current working directory, rather than
  * relative to the path of the config file.
  */
-export async function withByronConfigDir(
-  cb: (configDir: string) => Promise<void>
-) {
+export async function withByronConfigDir<T>(
+  cb: (configDir: string) => Promise<T>
+): Promise<T> {
   const base = process.env.BYRON_CONFIGS;
   if (!base) {
     const msg =
@@ -149,7 +146,7 @@ export async function withByronConfigDir(
           genesis: 'mainnet-genesis.json',
           topology: 'mainnet-topology.json',
         },
-        f => {
+        (f: string) => {
           return { src: path.join(base, f), dst: path.join(o.path, f) };
         }
       );


### PR DESCRIPTION
This enables more eslint recommended rules presets.

The warnings/errors fixed were:

<details><summary>Expand</summary>
<pre><u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/cardanoLauncher.ts</u>
  118:27  <font color="#CC0000">error</font>    Don&apos;t use &apos;Boolean&apos; as a type. Use boolean instead    @typescript-eslint/ban-types
  181:19  <font color="#CC0000">error</font>    &apos;makeServiceCommands&apos; was used before it was defined  @typescript-eslint/no-use-before-define
  194:15  <font color="#C4A000">warning</font>  Missing return type on function                       @typescript-eslint/explicit-function-return-type
  194:25  <font color="#CC0000">error</font>    &apos;V2Api&apos; was used before it was defined                @typescript-eslint/no-use-before-define
  239:25  <font color="#C4A000">warning</font>  Missing return type on function                       @typescript-eslint/explicit-function-return-type
  253:20  <font color="#CC0000">error</font>    &apos;BackendExitedError&apos; was used before it was defined   @typescript-eslint/no-use-before-define
  271:5   <font color="#CC0000">error</font>    Unexpected var, use let or const instead              no-var
  272:18  <font color="#C4A000">warning</font>  Missing return type on function                       @typescript-eslint/explicit-function-return-type
  274:23  <font color="#CC0000">error</font>    &apos;timer&apos; was used before it was defined                @typescript-eslint/no-use-before-define
  289:25  <font color="#CC0000">error</font>    &apos;timer&apos; was used before it was defined                @typescript-eslint/no-use-before-define
  375:9   <font color="#CC0000">error</font>    &apos;hostname&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  376:9   <font color="#CC0000">error</font>    &apos;path&apos; is never reassigned. Use &apos;const&apos; instead       prefer-const
  397:11  <font color="#CC0000">error</font>    &apos;exitStatusMessage&apos; was used before it was defined    @typescript-eslint/no-use-before-define
  459:5   <font color="#CC0000">error</font>    &apos;nodeExe&apos; was used before it was defined              @typescript-eslint/no-use-before-define
  462:5   <font color="#CC0000">error</font>    &apos;walletExe&apos; was used before it was defined            @typescript-eslint/no-use-before-define
  470:3   <font color="#C4A000">warning</font>  &apos;node&apos; is defined but never used                      @typescript-eslint/no-unused-vars

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/cli.ts</u>
   30:8   <font color="#C4A000">warning</font>  Missing return type on function                    @typescript-eslint/explicit-function-return-type
   31:47  <font color="#CC0000">error</font>    Unexpected empty function                          @typescript-eslint/no-empty-function
   38:5   <font color="#CC0000">error</font>    &apos;usage&apos; was used before it was defined             @typescript-eslint/no-use-before-define
   46:19  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type           @typescript-eslint/no-explicit-any
   71:5   <font color="#CC0000">error</font>    &apos;usage&apos; was used before it was defined             @typescript-eslint/no-use-before-define
   81:18  <font color="#CC0000">error</font>    &apos;sendMaybe&apos; was used before it was defined         @typescript-eslint/no-use-before-define
   85:18  <font color="#CC0000">error</font>    &apos;sendMaybe&apos; was used before it was defined         @typescript-eslint/no-use-before-define
   92:18  <font color="#CC0000">error</font>    &apos;combineStatus&apos; was used before it was defined     @typescript-eslint/no-use-before-define
   97:7   <font color="#CC0000">error</font>    &apos;code&apos; is never reassigned. Use &apos;const&apos; instead    prefer-const
  102:7   <font color="#CC0000">error</font>    &apos;signal&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  112:1   <font color="#C4A000">warning</font>  Missing return type on function                    @typescript-eslint/explicit-function-return-type
  125:1   <font color="#C4A000">warning</font>  Missing return type on function                    @typescript-eslint/explicit-function-return-type

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/common.ts</u>
  22:8   <font color="#C4A000">warning</font>  Missing return type on function                     @typescript-eslint/explicit-function-return-type
  36:8   <font color="#C4A000">warning</font>  Missing return type on function                     @typescript-eslint/explicit-function-return-type
  36:40  <font color="#C4A000">warning</font>  &apos;_&apos; is defined but never used                       @typescript-eslint/no-unused-vars
  36:50  <font color="#CC0000">error</font>    Unexpected empty function &apos;ignorePromiseRejection&apos;  @typescript-eslint/no-empty-function

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/jormungandr.ts</u>
   27:3   <font color="#CC0000">error</font>  Identifier &apos;itn_rewards_v1&apos; is not in camel case  @typescript-eslint/camelcase
  116:16  <font color="#CC0000">error</font>  &apos;makeArgs&apos; was used before it was defined         @typescript-eslint/no-use-before-define

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/logging.ts</u>
  25:25  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  36:18  <font color="#C4A000">warning</font>  Missing return type on function           @typescript-eslint/explicit-function-return-type
  39:13  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  49:12  <font color="#C4A000">warning</font>  Missing return type on function           @typescript-eslint/explicit-function-return-type
  49:34  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  50:11  <font color="#C4A000">warning</font>  Missing return type on function           @typescript-eslint/explicit-function-return-type
  50:33  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  51:12  <font color="#C4A000">warning</font>  Missing return type on function           @typescript-eslint/explicit-function-return-type
  51:34  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/service.ts</u>
  160:19  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type
  190:5   <font color="#CC0000">error</font>    &apos;setStatus&apos; was used before it was defined                                    @typescript-eslint/no-use-before-define
  192:7   <font color="#CC0000">error</font>    &apos;onStopped&apos; was used before it was defined                                    @typescript-eslint/no-use-before-define
  196:7   <font color="#CC0000">error</font>    &apos;onStopped&apos; was used before it was defined                                    @typescript-eslint/no-use-before-define
  209:18  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type
  211:5   <font color="#CC0000">error</font>    &apos;setStatus&apos; was used before it was defined                                    @typescript-eslint/no-use-before-define
  229:21  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type
  241:5   <font color="#CC0000">error</font>    &apos;setStatus&apos; was used before it was defined                                    @typescript-eslint/no-use-before-define
  287:12  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type
  310:18  <font color="#CC0000">error</font>    Type number trivially inferred from a number literal, remove type annotation  @typescript-eslint/no-inferrable-types
  336:16  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type
  337:17  <font color="#C4A000">warning</font>  Missing return type on function                                               @typescript-eslint/explicit-function-return-type

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/src/shelley.ts</u>
  29:39  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  38:3   <font color="#C4A000">warning</font>  &apos;config&apos; is defined but never used        @typescript-eslint/no-unused-vars

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/test/cli.test.ts</u>
  26:40  <font color="#C4A000">warning</font>  Missing return type on function           @typescript-eslint/explicit-function-return-type
  41:34  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  55:38  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  56:40  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  59:3   <font color="#C4A000">warning</font>  Test has no assertions                    jest/expect-expect
  68:3   <font color="#C4A000">warning</font>  Test has no assertions                    jest/expect-expect

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/test/integration.test.ts</u>
   21:29  <font color="#C4A000">warning</font>  Missing return type on function                @typescript-eslint/explicit-function-return-type
   49:31  <font color="#C4A000">warning</font>  Missing return type on function                @typescript-eslint/explicit-function-return-type
   55:24  <font color="#C4A000">warning</font>  Missing return type on function                @typescript-eslint/explicit-function-return-type
   66:17  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type       @typescript-eslint/no-explicit-any
   72:27  <font color="#C4A000">warning</font>  Unexpected any. Specify a different type       @typescript-eslint/no-explicit-any
   90:3   <font color="#C4A000">warning</font>  Test has no assertions                         jest/expect-expect
  106:3   <font color="#C4A000">warning</font>  Test has no assertions                         jest/expect-expect
  145:27  <font color="#CC0000">error</font>    Use toHaveLength() instead                     jest/prefer-to-have-length
  172:7   <font color="#CC0000">error</font>    Expect must have a corresponding matcher call  jest/valid-expect

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/test/unit.test.ts</u>
   21:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
   22:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
   41:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
   42:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
   44:9   <font color="#CC0000">error</font>  &apos;pid&apos; is never reassigned. Use &apos;const&apos; instead      prefer-const
   45:9   <font color="#CC0000">error</font>  &apos;result&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
   53:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
   54:9   <font color="#CC0000">error</font>  &apos;pid&apos; is never reassigned. Use &apos;const&apos; instead      prefer-const
   55:9   <font color="#CC0000">error</font>  &apos;result&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  111:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  112:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  113:9   <font color="#CC0000">error</font>  &apos;pid1&apos; is never reassigned. Use &apos;const&apos; instead     prefer-const
  114:9   <font color="#CC0000">error</font>  &apos;pid2&apos; is never reassigned. Use &apos;const&apos; instead     prefer-const
  130:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  131:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  132:9   <font color="#CC0000">error</font>  &apos;pid&apos; is never reassigned. Use &apos;const&apos; instead      prefer-const
  133:9   <font color="#CC0000">error</font>  &apos;result1&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  134:9   <font color="#CC0000">error</font>  &apos;result2&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  150:45  <font color="#CC0000">error</font>  Illegal usage of test callback                      jest/no-test-callback
  151:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  152:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  153:9   <font color="#CC0000">error</font>  &apos;pidP&apos; is never reassigned. Use &apos;const&apos; instead     prefer-const
  185:9   <font color="#CC0000">error</font>  &apos;logger&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  186:9   <font color="#CC0000">error</font>  &apos;service&apos; is never reassigned. Use &apos;const&apos; instead  prefer-const
  187:9   <font color="#CC0000">error</font>  &apos;events&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  189:9   <font color="#CC0000">error</font>  &apos;result&apos; is never reassigned. Use &apos;const&apos; instead   prefer-const
  200:73  <font color="#CC0000">error</font>  Use toHaveLength() instead                          jest/prefer-to-have-length

<u style="text-decoration-style:single">/home/rodney/iohk/cardano-launcher/test/utils.ts</u>
   33:3   <font color="#CC0000">error</font>    Type number trivially inferred from a number literal, remove type annotation    @typescript-eslint/no-inferrable-types
   42:7   <font color="#CC0000">error</font>    &apos;events&apos; is never reassigned. Use &apos;const&apos; instead                               prefer-const
   57:28  <font color="#CC0000">error</font>    Type boolean trivially inferred from a boolean literal, remove type annotation  @typescript-eslint/no-inferrable-types
   58:7   <font color="#CC0000">error</font>    &apos;logs&apos; is never reassigned. Use &apos;const&apos; instead                                 prefer-const
   61:12  <font color="#C4A000">warning</font>  Missing return type on function                                                 @typescript-eslint/explicit-function-return-type
   77:14  <font color="#C4A000">warning</font>  Missing return type on function                                                 @typescript-eslint/explicit-function-return-type
   81:8   <font color="#C4A000">warning</font>  Missing return type on function                                                 @typescript-eslint/explicit-function-return-type
  113:8   <font color="#C4A000">warning</font>  Missing return type on function                                                 @typescript-eslint/explicit-function-return-type
  133:8   <font color="#C4A000">warning</font>  Missing return type on function                                                 @typescript-eslint/explicit-function-return-type

<font color="#CC0000"><b>✖ 108 problems (62 errors, 46 warnings)</b></font>
<font color="#CC0000"><b>  39 errors and 0 warnings potentially fixable with the `--fix` option.</b></font>

</pre>
</details>