### PR TITLE
Feature/support storing service logs in separate files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc",
     "test": "jest",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepare": "npm run build",
     "typedoc": "typedoc src"
   },

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -187,9 +187,12 @@ export interface LaunchConfig {
     | jormungandr.JormungandrConfig;
 
   /**
-   *  WriteStream for writing the child process data events from stdout and stderr
+   *  WriteStreams for the child process data events from stdout and stderr
    */
-  childProcessLogWriteStream?: WriteStream;
+  childProcessLogWriteStreams?: {
+    node: WriteStream;
+    wallet: WriteStream;
+  };
 
   /**
    *  Control the termination signal handling. Set this to false if the default
@@ -262,19 +265,22 @@ export class Launcher {
    */
   constructor(config: LaunchConfig, logger: Logger = console) {
     logger.debug('Launcher init');
-    const { childProcessLogWriteStream, installSignalHandlers = true } = config;
+    const {
+      childProcessLogWriteStreams,
+      installSignalHandlers = true,
+    } = config;
     this.logger = logger;
 
     const start = Launcher.makeServiceCommands(config, logger);
     this.walletService = setupService(
       start.wallet,
       prependName(logger, 'wallet'),
-      childProcessLogWriteStream
+      childProcessLogWriteStreams?.wallet
     );
     this.nodeService = setupService(
       start.node,
       prependName(logger, 'node'),
-      childProcessLogWriteStream
+      childProcessLogWriteStreams?.node
     );
 
     this.walletBackend = {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -75,14 +75,23 @@ describe('Starting cardano-wallet (and its node)', () => {
     const info: any = await new Promise((resolve, reject) => {
       console.log('running req');
       const networkModule = tls ? https : http;
-      const req = networkModule.request(makeRequest(api, 'network/information', tls ? {
-        ca: fs.readFileSync(path.join(tlsDir, 'ca.crt')),
-        cert: fs.readFileSync(path.join(tlsDir, 'client.crt')),
-        key: fs.readFileSync(path.join(tlsDir, 'client.key'))
-      } : {}), res => {
-        res.setEncoding('utf8');
-        res.on('data', d => resolve(JSON.parse(d)));
-      });
+      const req = networkModule.request(
+        makeRequest(
+          api,
+          'network/information',
+          tls
+            ? {
+                ca: fs.readFileSync(path.join(tlsDir, 'ca.crt')),
+                cert: fs.readFileSync(path.join(tlsDir, 'client.crt')),
+                key: fs.readFileSync(path.join(tlsDir, 'client.key')),
+              }
+            : {}
+        ),
+        res => {
+          res.setEncoding('utf8');
+          res.on('data', d => resolve(JSON.parse(d)));
+        }
+      );
       req.on('error', (e: Error) => {
         console.error(`problem with request: ${e.message}`);
         reject(e);
@@ -195,6 +204,7 @@ describe('Starting cardano-wallet (and its node)', () => {
     await launcher.stop();
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('can configure the cardano-wallet-byron to serve the API with TLS', async () =>
     withByronConfigDir(configurationDir =>
       launcherTest(stateDir => {
@@ -207,14 +217,13 @@ describe('Starting cardano-wallet (and its node)', () => {
             network: byron.networks.mainnet,
           },
           tlsConfiguration: {
-            caCert: path.join(tlsDir,'ca.crt'),
+            caCert: path.join(tlsDir, 'ca.crt'),
             svCert: path.join(tlsDir, 'server.crt'),
-            svKey: path.join(tlsDir, 'server.key')
-          }
+            svKey: path.join(tlsDir, 'server.key'),
+          },
         };
       }, true)
-    )
-  )
+    ));
 
   it('handles case where (jormungandr) node fails to start', async () => {
     const { launcher, cleanupLauncher } = await setupTestLauncher(stateDir => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -59,7 +59,7 @@ describe('Starting cardano-wallet (and its node)', () => {
 
   const launcherTest = async (
     config: (stateDir: string) => LaunchConfig,
-    tls: boolean = false
+    tls = false
   ): Promise<void> => {
     setupExecPath();
 
@@ -164,31 +164,36 @@ describe('Starting cardano-wallet (and its node)', () => {
     await cleanupLauncher();
   });
 
-  it('Accepts a WriteStream, and pipes the child process stdout and stderr streams', () =>
-    tmp.withFile(async (logFile: tmp.FileResult) => {
-      const childProcessLogWriteStream = fs.createWriteStream(logFile.path, {
-        fd: logFile.fd,
-      });
-      const launcher = new Launcher({
-        stateDir: (
-          await tmp.dir({
-            unsafeCleanup: true,
-            prefix: 'launcher-integration-test-2',
-          })
-        ).path,
-        networkName: 'self',
-        nodeConfig: {
-          kind: 'jormungandr',
-          configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
-          network: jormungandr.networks.self,
-        },
-        childProcessLogWriteStream,
-      });
-      await launcher.start();
-      const logFileStats = await stat(logFile.path);
-      expect(logFileStats.size).toBeGreaterThan(0);
-      await launcher.stop();
-    }));
+  it('Accepts a WriteStream, and pipes the child process stdout and stderr streams', async () => {
+    const walletLogFile = await tmp.file();
+    const nodeLogFile = await tmp.file();
+    const launcher = new Launcher({
+      stateDir: (
+        await tmp.dir({
+          unsafeCleanup: true,
+          prefix: 'launcher-integration-test-',
+        })
+      ).path,
+      networkName: 'self',
+      nodeConfig: {
+        kind: 'jormungandr',
+        configurationDir: path.resolve(__dirname, 'data', 'jormungandr'),
+        network: jormungandr.networks.self,
+      },
+      childProcessLogWriteStreams: {
+        node: fs.createWriteStream(nodeLogFile.path, { fd: nodeLogFile.fd }),
+        wallet: fs.createWriteStream(walletLogFile.path, {
+          fd: walletLogFile.fd,
+        }),
+      },
+    });
+    await launcher.start();
+    const nodeLogFileStats = await stat(nodeLogFile.path);
+    const walletLogFileStats = await stat(walletLogFile.path);
+    expect(nodeLogFileStats.size).toBeGreaterThan(0);
+    expect(walletLogFileStats.size).toBeGreaterThan(0);
+    await launcher.stop();
+  });
 
   it('can configure the cardano-wallet-byron to serve the API with TLS', async () =>
     withByronConfigDir(configurationDir =>

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -9,8 +9,8 @@ import _ from 'lodash';
 import { Service, ServiceStatus, Api } from '../src';
 import { StartService, ShutdownMethod } from '../src/service';
 import { Logger, LogFunc } from '../src/logging';
-import { ServerOptions } from 'http'
-import { ServerOptions as HttpsServerOptions } from 'https'
+import { ServerOptions } from 'http';
+import { ServerOptions as HttpsServerOptions } from 'https';
 
 /*******************************************************************************
  * Utils
@@ -86,7 +86,11 @@ export function delay(ms: number): Promise<void> {
  * @param options - extra options to be added to the request.
  * @return an options object suitable for `http.request`
  */
-export function makeRequest(api: Api, path: string, options?: ServerOptions | HttpsServerOptions): object {
+export function makeRequest(
+  api: Api,
+  path: string,
+  options?: ServerOptions | HttpsServerOptions
+): object {
   return Object.assign(
     {},
     api.requestParams,


### PR DESCRIPTION
Closes #55. I elected to keep the interface simple, and just change the property to require a keyed object. The linter was also not checking `/tests`,  so this PR fixes that.

~Draft until #66 is merged.~

