### PR TITLE
Fix shell.nix on macOS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,8 @@ mkShell {
     # javascript
     nodejs nodePackages.npm
     # documentation tools
-    pandoc mscgen librsvg gnumake
+    pandoc librsvg gnumake
+  ] ++ lib.optional stdenv.isLinux mscgen ++ [
     # util to update nixpkgs pins
     niv.niv
     # cardano jormungandr


### PR DESCRIPTION
In nixpkgs 20.03, mscgen only builds on Linux. It's just for generating diagrams anyway.