### PR TITLE
Remove byron backend

### DIFF
--- a/docs/example.js
+++ b/docs/example.js
@@ -1,5 +1,4 @@
 // Example of launching the wallet for mainnet.
-// (Byron rewrite of cardano-node)
 
 var cardanoLauncher = require("cardanoLauncher");
 
@@ -7,12 +6,7 @@ var launcher = new cardanoLauncher.Launcher({
   networkName: "mainnet",
   stateDir: "/tmp/state-launcher",
   nodeConfig: {
-    kind: "byron",
-    configurationDir: "/home/rodney/iohk/cardano-node/configuration/defaults/mainnet",
-    network: {
-      configFile: "configuration.yaml",
-      topologyFile: "topology.json"
-    }
+    kind: "shelley"
   }
 });
 

--- a/shell.nix
+++ b/shell.nix
@@ -16,16 +16,14 @@ mkShell {
     cardanoWalletPackages.cardano-wallet-jormungandr
     # cardano-node
     cardano-node
-    cardanoWalletPackages.cardano-wallet-byron
     cardanoWalletPackages.cardano-wallet-shelley
   ];
 
   # Test data from cardano-wallet repo used in their integration tests.
-  TEST_CONFIG_BYRON = cardanoWalletPackages.src + /lib/byron/test/data/cardano-node-byron;
   TEST_CONFIG_SHELLEY = cardanoWalletPackages.src + /lib/shelley/test/data/cardano-node-shelley;
 
   # Contents of configuration subdirectory of cardano-node repo.
-  BYRON_CONFIGS = cardanoWalletPackages.cardano-node.configs;
+  SRC_CONFIGS = cardanoWalletPackages.cardano-node.configs;
 
   # Corresponds to
   # https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/index.html

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -394,12 +394,6 @@ export class Launcher {
     switch (config.nodeConfig.kind) {
       case 'jormungandr':
         return jormungandr.startJormungandr(baseDir, config.nodeConfig);
-      case 'byron':
-        return cardanoNode.startCardanoNode(
-          baseDir,
-          config.nodeConfig,
-          config.networkName
-        );
       case 'shelley':
         return cardanoNode.startCardanoNode(
           baseDir,

--- a/src/cardanoWallet.ts
+++ b/src/cardanoWallet.ts
@@ -81,7 +81,6 @@ export interface LaunchConfig {
 
   /**
    * Configuration for starting `cardano-node`. The `kind` property will be one of
-   *  * `"byron"` - [[ByronNodeConfig]]
    *  * `"shelley"` - [[ShelleyNodeConfig]]
    *  * `"jormungandr"` - [[JormungandrConfig]]
    */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ import * as jormungandr from './jormungandr';
 
 function usage(): void {
   console.log('usage: cardano-launcher BACKEND NETWORK CONFIG-DIR STATE-DIR');
-  console.log('  BACKEND    - either jormungandr, byron, or shelley');
+  console.log('  BACKEND    - either jormungandr or shelley');
   console.log(
     '  NETWORK    - depends on backend, e.g. mainnet, itn_rewards_v1'
   );
@@ -80,7 +80,7 @@ export function cli(argv: Process['argv']): void {
 
   let nodeConfig: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-  if (backend === 'byron' || backend === 'shelley') {
+  if (backend === 'shelley') {
     if (!(networkName in cardanoNode.networks)) {
       console.error(`unknown network: ${networkName}`);
       process.exit(2);


### PR DESCRIPTION
Relates to issue #80.

- Remove the byron cardano-node configuration.
- Make setting up a shelley launcher easier by providing some default values.
