### PR TITLE
Update for cardano-wallet-shelley -> cardano-wallet renaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         run: |
           node scripts\download-hydra.js
           Get-ChildItem
-          Expand-Archive -Force -Path "cardano-wallet-jormungandr-*-win64.zip" -DestinationPath .
-          Expand-Archive -Force -Path "cardano-wallet-shelley-*-win64.zip" -DestinationPath .
-          Expand-Archive -Force -Path "cardano-wallet-shelley-*-deployments.zip" -DestinationPath shelley_deployments
+          Expand-Archive -Force -Path "cardano-wallet-jormungandr-20*-win64.zip" -DestinationPath .
+          Expand-Archive -Force -Path "cardano-wallet-20*-win64.zip" -DestinationPath .
+          Expand-Archive -Force -Path "cardano-wallet-*-deployments.zip" -DestinationPath deployments
           Get-ChildItem
-          echo "::set-env name=CARDANO_NODE_CONFIGS::$Env:GITHUB_WORKSPACE\shelley_deployments"
+          echo "::set-env name=CARDANO_NODE_CONFIGS::$Env:GITHUB_WORKSPACE\deployments"
       - run: npm test unit
       - run: npm test integration
       - run: npm test cli

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "c93a28de4e4385da0b72ee989060f3dae71ee354",
-        "sha256": "1lf132by2hbjr5a8iamw5m8xcyqszcjvqbnh1na1m52chvx7145n",
+        "rev": "5c1240cc668993fcb7135f244f2b1cc9c96a3238",
+        "sha256": "0fwgigcl11jwr34pbv92099z67j18wr2132a1zbr19llkg220mlr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/c93a28de4e4385da0b72ee989060f3dae71ee354.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/5c1240cc668993fcb7135f244f2b1cc9c96a3238.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/scripts/download-hydra.js
+++ b/scripts/download-hydra.js
@@ -157,7 +157,7 @@ async function download(sourceName, downloads) {
 }
 
 download("cardano-wallet", [{
-  job: "cardano-wallet-shelley-win64",
+  job: "cardano-wallet-win64",
   buildProducts: [1, 3]
 }, {
   job: "cardano-wallet-jormungandr-win64",

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ mkShell {
     cardanoWalletPackages.cardano-wallet-jormungandr
     # cardano-node
     cardano-node
-    cardanoWalletPackages.cardano-wallet-shelley
+    cardanoWalletPackages.cardano-wallet
   ];
 
   # Test data from cardano-wallet repo used in their integration tests.

--- a/src/cardanoWallet.ts
+++ b/src/cardanoWallet.ts
@@ -121,8 +121,10 @@ export async function startCardanoWallet(
   config: LaunchConfig
 ): Promise<WalletStartService> {
   const apiPort = config.apiPort || (await getPort());
+  const commandSuffix =
+    config.nodeConfig.kind === 'shelley' ? '' : '-' + config.nodeConfig.kind;
   const base: WalletStartService = {
-    command: `cardano-wallet-${config.nodeConfig.kind}`,
+    command: 'cardano-wallet' + commandSuffix,
     args: [
       'serve',
       '--shutdown-handler',

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -139,7 +139,7 @@ describe('Starting cardano-wallet (and its node)', () => {
 
   // eslint-disable-next-line jest/expect-expect
   it(
-    'cardano-wallet-shelley responds to requests',
+    'cardano-wallet responds to requests',
     () =>
       launcherTest(stateDir => {
         return {
@@ -260,7 +260,7 @@ describe('Starting cardano-wallet (and its node)', () => {
 
   // eslint-disable-next-line jest/expect-expect
   it(
-    'can configure the cardano-wallet-shelley to serve the API with TLS',
+    'can configure the cardano-wallet to serve the API with TLS',
     async () =>
       launcherTest(stateDir => {
         return {


### PR DESCRIPTION
Relates to issue #80.

`cardano-wallet-shelley` got renamed to `cardano-wallet`. This updates the CI pipelines and service launching code accordingly.
