### PR TITLE
Fix a few typedocs and publish on release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -18,3 +18,22 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm install --ci --logevel=error
+      - name: Install extra doc tools
+        run: sudo apt-get install -yu mscgen librsvg2-bin pandoc
+      - name: Build typedocs
+        run: |
+          git config user.name "William King Noel Bot"
+          git config user.email "adrestia@iohk.io"
+          ./scripts/update-gh-pages.sh
+      - name: Deploy to gh-pages
+        run: git push origin gh-pages

--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -32,7 +32,7 @@ import {
 } from './common';
 import {
   LaunchConfig,
-  startCardanoWallet,
+  cardanoWalletStartService,
   WalletStartService,
 } from './cardanoWallet';
 
@@ -384,7 +384,7 @@ export class Launcher {
     baseDir: DirPath,
     config: LaunchConfig
   ): Promise<WalletStartService> {
-    return startCardanoWallet(baseDir, config);
+    return cardanoWalletStartService(baseDir, config);
   }
 
   private static nodeExe(

--- a/src/cardanoNode.ts
+++ b/src/cardanoNode.ts
@@ -158,7 +158,7 @@ let pipeCounter = 0;
  * The name also includes a per-process counter, mostly so that
  * integration tests do not conflict with each other.
  *
- * @networkName: which network to put in the pipe name.
+ * @param networkName: which network to put in the pipe name.
  * @return a [Pipe Name](https://docs.microsoft.com/en-us/windows/win32/ipc/pipe-names)
  */
 function windowsPipeName(networkName: string): string {

--- a/src/cardanoWallet.ts
+++ b/src/cardanoWallet.ts
@@ -4,7 +4,7 @@
 /**
  * Module for starting and managing the cardano-wallet process.
  *
- * The main function is [[startCardanoWallet]].
+ * The main function is [[cardanoWalletStartService]].
  *
  * @packageDocumentation
  */
@@ -90,7 +90,7 @@ export interface LaunchConfig {
 
   /**
    * Configuration for starting `cardano-node`. The `kind` property will be one of
-   *  * `"shelley"` - [[ShelleyNodeConfig]]
+   *  * `"shelley"` - [[CardanoNodeConfig]]
    *  * `"jormungandr"` - [[JormungandrConfig]]
    */
   nodeConfig: cardanoNode.CardanoNodeConfig | jormungandr.JormungandrConfig;
@@ -122,10 +122,23 @@ export interface LaunchConfig {
  ******************************************************************************/
 
 export interface WalletStartService extends StartService {
+  /** This will contain the port which the API is listening on,
+   *  after the service has started. */
   apiPort: number;
 }
 
-export async function startCardanoWallet(
+/**
+ * Produces a [[WalletStartService]] description of how to start
+ * `cardano-wallet` with a given [[LaunchConfig]].
+ *
+ * Does not actually start the wallet.
+ *
+ * @param baseDir - The state directory, under which `cardano-wallet`
+ *   shall store its databases.
+ * @param config - Parameters for starting the server.
+ * @return The launch instructions.
+ */
+export async function cardanoWalletStartService(
   baseDir: DirPath,
   config: LaunchConfig
 ): Promise<WalletStartService> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -67,16 +67,18 @@ export enum ServiceStatus {
  */
 export interface Service {
   /**
-   * @return a promise that will be fulfilled when the process has
-   *   started. The returned PID is not guaranteed to be running. It may
-   *   already have exited.
+   * @return - a promise that will be fulfilled when the process has
+   *   started. The returned PID is not guaranteed to be running. It
+   *   may already have exited.
    */
   start(): Promise<Pid>;
 
   /**
    * Stops the process.
-   * @param timeoutSeconds - how long to wait for the service to stop itself before killing it.
-   *   If `0`, any running timeout kill be cancelled and the process killed immediately.
+   *
+   * @param timeoutSeconds - How long to wait for the service to stop
+   *   itself before killing it. If `0`, any running timeout kill be
+   *   cancelled and the process killed immediately.
    * @return a promise that will be fulfilled when the process has stopped.
    */
   stop(timeoutSeconds?: number): Promise<ServiceExitStatus>;
@@ -95,7 +97,8 @@ export interface Service {
   getStatus(): ServiceStatus;
 
   /**
-   * @return the ChildProcess running the service, or null if the service has not been started yet.
+   * @return the ChildProcess running the service, or null if
+   *   the service has not been started yet.
    */
   getProcess(): ChildProcess | null;
 


### PR DESCRIPTION
- Fix some broken typedoc tags, minor formatting fixes, etc.
- Run the gh-pages script with the postrelease github workflow (I tested it in `ci.yml`, then moved to `post-release.yml`).
