### PR TITLE
Add rtsOpts to CardanoNodeConfig

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -34,3 +34,14 @@ export function passthroughErrorLogger(err: Error): void {
  * eslint warning from appearing.
  */
 export function ignorePromiseRejection(_: Error): void {} // eslint-disable-line
+
+/**
+ * Format GHC RTS options for the command line.
+ *
+ * See: https://downloads.haskell.org/ghc/8.10.7/docs/html/users_guide/runtime_control.html#setting-rts-options-on-the-command-line
+ */
+export function makeRtsArgs(rtsOpts?: string[]): string[] {
+  return Array.isArray(rtsOpts) && rtsOpts.length
+    ? ['+RTS'].concat(rtsOpts as string[]).concat(['-RTS'])
+    : [];
+}

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -8,7 +8,7 @@ import * as https from 'https';
 import * as tmp from 'tmp-promise';
 import * as path from 'path';
 import * as fs from 'fs';
-import { stat } from 'fs-extra';
+import { stat, pathExists } from 'fs-extra';
 
 import * as cardanoNode from '../src/cardanoNode';
 import { ExitStatus } from '../src/cardanoLauncher';
@@ -258,6 +258,31 @@ describe('Starting cardano-wallet (and its node)', () => {
         );
       }
 
+      await launcher.stop(defaultStopTimeout);
+    },
+    veryLongTestTimeoutMs
+  );
+
+  it(
+    'applies RTS options to cardano-node',
+    async () => {
+      let hp = 'cardano-node.hp';
+      const launcher = await setupTestLauncher(stateDir => {
+        hp = path.join(stateDir, hp);
+        return {
+          stateDir,
+          networkName: 'testnet',
+          nodeConfig: {
+            kind: 'shelley',
+            configurationDir: getShelleyConfigDir('testnet'),
+            network: cardanoNode.networks.testnet,
+            rtsOpts: ['-h'], // generates a basic heap profile
+          },
+        };
+      });
+
+      await launcher.start();
+      expect(await pathExists(hp)).toBe(true);
       await launcher.stop(defaultStopTimeout);
     },
     veryLongTestTimeoutMs


### PR DESCRIPTION
Adds API to allow configuration of the GHC RTS options used for running `cardano-node`.

### Issue

ADP-1173
