### PR TITLE
Increase default kill timeout from 1 minute to 5 minutes

### DIFF
--- a/src/cardanoLauncher.ts
+++ b/src/cardanoLauncher.ts
@@ -24,6 +24,7 @@ import {
   StartService,
   setupService,
   serviceExitStatusMessage,
+  defaultTimeoutSeconds,
 } from './service';
 import {
   DirPath,
@@ -316,9 +317,11 @@ export class Launcher {
   }
 
   /**
-   * Stops the wallet backend. Attempts to cleanly shut down the
-   * processes. However, if they have not exited before the timeout,
-   * they will be killed.
+   * Stops the wallet and node backends.
+   *
+   * Attempts to cleanly shut down the processes. However, if they
+   * have not exited before the timeout, they will be killed. The
+   * default timeout is [[defaultTimeoutSeconds]].
    *
    * @param timeoutSeconds - how long to wait before killing the processes.
    * @return a [[Promise]] that is fulfilled at the timeout, or before.
@@ -327,7 +330,7 @@ export class Launcher {
    *   wallet and node have both exited.
    */
   stop(
-    timeoutSeconds = 60
+    timeoutSeconds = defaultTimeoutSeconds
   ): Promise<{ wallet: ServiceExitStatus; node: ServiceExitStatus }> {
     this.logger.debug(`Launcher.stop: stopping wallet and node`);
     return Promise.all([

--- a/src/service.ts
+++ b/src/service.ts
@@ -76,6 +76,9 @@ export interface Service {
   /**
    * Stops the process.
    *
+   * If the process doesn't exit within `timeoutSeconds`, it will be
+   * killed. The default timeout is [[defaultTimeoutSeconds]].
+   *
    * @param timeoutSeconds - How long to wait for the service to stop
    *   itself before killing it. If `0`, any running timeout kill be
    *   cancelled and the process killed immediately.
@@ -156,6 +159,11 @@ export enum ShutdownMethod {
  * notification when [[ShutdownMethod.CloseFD]] is in use.
  */
 export const cleanShutdownFD = 3;
+
+/**
+ * The value for the `timeoutSeconds` argument of [[Service.stop]].
+ */
+export const defaultTimeoutSeconds = 300;
 
 /**
  * Initialise a [[Service]] which can control the lifetime of a
@@ -366,7 +374,9 @@ export function setupService(
           return -1;
       }
     },
-    stop: async (timeoutSeconds = 60): Promise<ServiceExitStatus> => {
+    stop: async (
+      timeoutSeconds = defaultTimeoutSeconds
+    ): Promise<ServiceExitStatus> => {
       switch (status) {
         case ServiceStatus.NotStarted:
         case ServiceStatus.Starting:


### PR DESCRIPTION
Increases the `Service.stop()` default timeout and adds more documentation about it.
 
### Issue

ADP-1187
