### PR TITLE
Do not merge: Bump to input-output-hk/cardano-node#3320 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,22 @@ jobs:
           echo "REPO_NAME=$($sources.repo)" >> $Env:GITHUB_ENV
           echo "COMMIT=$($sources.rev)" >> $Env:GITHUB_ENV
 
+      - name: 'Fetch cardano-node'
+        shell: powershell
+        run: |
+          # https://stackoverflow.com/a/41618979
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          # Fetch latest windows build for jobset
+          $output = "cardano-node-win64.zip"
+          $url = "https://hydra.iohk.io/job/Cardano/${Env:jobset}/cardano-node-win64/latest/download/1"
+          echo "Build product URL: ${url}"
+          Invoke-WebRequest -MaximumRedirection 5 -Uri $url -OutFile $output
+          # Unzip
+          Expand-Archive -Force -Path $output -DestinationPath .
+          Get-ChildItem
+        env:
+          jobset: cardano-node-pr-3320
+
       - name: 'Wait for Hydra build'
         uses: rvl/hydra-build-products-action@master
         id: hydra
@@ -108,6 +124,12 @@ jobs:
           Expand-Archive -Force -Path "cardano-wallet-*-deployments.zip" -DestinationPath deployments
           Get-ChildItem
           echo "CARDANO_NODE_CONFIGS=$Env:GITHUB_WORKSPACE\deployments" >> $Env:GITHUB_ENV
+
+      - name: 'Unpack cardano-node again'
+        shell: powershell
+        run: |
+          Expand-Archive -Force -Path "cardano-node*.zip" -DestinationPath .
+          Get-ChildItem
 
       - name: 'Setup nodejs'
         uses: actions/setup-node@v2

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "b3e3fcf59255ae0b5988b4cda61d3cff1415c36d",
-        "sha256": "05vf64khxxmxk9wcqjlb648398fnyrjh3xn6g1sx4hy1nxk07ddm",
+        "rev": "333a07d95046ee2a80e42adb0d94fbc1f282e3bc",
+        "sha256": "02m4rszlgx94lkpwldjcmmcmc4pbbnqilvgvjjrdskp9b0gakg7h",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/b3e3fcf59255ae0b5988b4cda61d3cff1415c36d.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/333a07d95046ee2a80e42adb0d94fbc1f282e3bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "cardano-node": {
+        "branch": "jordan/separate-shutdown-ipc-shutdown-on-slot",
+        "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
+        "homepage": "https://cardano.org",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "4555bff83e311c2d30a51a0f0e91b2259d1cdfe8",
+        "sha256": "026iw803rpm4aa7r7b8f1lk5gwws2ip3k8s3aqfapkhvzjbq9s4w",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/4555bff83e311c2d30a51a0f0e91b2259d1cdfe8.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "cardano-wallet": {
         "branch": "master",
         "description": "Official Wallet Backend & API for Cardano decentralized",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "fee0b00c1436e6a0e5db58f75ae3b23e8d4be107",
-        "sha256": "17nln2shkd0m3s7a6kbrr9h786qp62dp3j6ya44ifn7bvz289wks",
+        "rev": "4b1e837e74205c5afd269fde75788d98504bb631",
+        "sha256": "1fzsxrzg4bqrmh779r04wjdz7kjw4dz78i46a1dd0754p44fb6ns",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/fee0b00c1436e6a0e5db58f75ae3b23e8d4be107.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/4b1e837e74205c5afd269fde75788d98504bb631.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "4b1e837e74205c5afd269fde75788d98504bb631",
-        "sha256": "1fzsxrzg4bqrmh779r04wjdz7kjw4dz78i46a1dd0754p44fb6ns",
+        "rev": "eadfe12024ec1daccf3df3364cb402cd24db9de2",
+        "sha256": "0f7myn653wdy8mb8h1zh5qjfinz14f4sjndqn625ndanbwal73m0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/4b1e837e74205c5afd269fde75788d98504bb631.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/eadfe12024ec1daccf3df3364cb402cd24db9de2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "dce68169d41f56ac469b87b432797e57256f6fc1",
-        "sha256": "1q321rsaa2mi3x9lcygii19l0js0vigzch03hc1fsnspv0n3adm2",
+        "rev": "2e671b662c4b1e5d266fa8bddb12b56b39985612",
+        "sha256": "0hkcn5ai1vgda37f2jl6xaawfy5484gadzf9xfckh1x2ngdp0ss2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/dce68169d41f56ac469b87b432797e57256f6fc1.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/2e671b662c4b1e5d266fa8bddb12b56b39985612.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "333a07d95046ee2a80e42adb0d94fbc1f282e3bc",
-        "sha256": "02m4rszlgx94lkpwldjcmmcmc4pbbnqilvgvjjrdskp9b0gakg7h",
+        "rev": "57240078f3a6e35bf27ef4685fa5f78221fc80e2",
+        "sha256": "1kkbfcfi01ls3cwf7h31102njwandrvvlddihfxxl75rn05pfqz0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/333a07d95046ee2a80e42adb0d94fbc1f282e3bc.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/57240078f3a6e35bf27ef4685fa5f78221fc80e2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "2e671b662c4b1e5d266fa8bddb12b56b39985612",
-        "sha256": "0hkcn5ai1vgda37f2jl6xaawfy5484gadzf9xfckh1x2ngdp0ss2",
+        "rev": "2966c58507c22b58e0698f0536ca182ff67a4e39",
+        "sha256": "1xa994d2rra7qpiqhlq7m6wcwbdkvjy0zispah30jk0mgg6s2rfp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/2e671b662c4b1e5d266fa8bddb12b56b39985612.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/2966c58507c22b58e0698f0536ca182ff67a4e39.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "4555bff83e311c2d30a51a0f0e91b2259d1cdfe8",
-        "sha256": "026iw803rpm4aa7r7b8f1lk5gwws2ip3k8s3aqfapkhvzjbq9s4w",
+        "rev": "7593f1756e75c842aed12f7ab00500143f2f6586",
+        "sha256": "0wpw9irxh62k4d4l5yk0h4560xkhdwpsv17rk4k3ydc8k0sslmhx",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/4555bff83e311c2d30a51a0f0e91b2259d1cdfe8.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/7593f1756e75c842aed12f7ab00500143f2f6586.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "7593f1756e75c842aed12f7ab00500143f2f6586",
-        "sha256": "0wpw9irxh62k4d4l5yk0h4560xkhdwpsv17rk4k3ydc8k0sslmhx",
+        "rev": "dce68169d41f56ac469b87b432797e57256f6fc1",
+        "sha256": "1q321rsaa2mi3x9lcygii19l0js0vigzch03hc1fsnspv0n3adm2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/7593f1756e75c842aed12f7ab00500143f2f6586.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/dce68169d41f56ac469b87b432797e57256f6fc1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "eadfe12024ec1daccf3df3364cb402cd24db9de2",
-        "sha256": "0f7myn653wdy8mb8h1zh5qjfinz14f4sjndqn625ndanbwal73m0",
+        "rev": "b3e3fcf59255ae0b5988b4cda61d3cff1415c36d",
+        "sha256": "05vf64khxxmxk9wcqjlb648398fnyrjh3xn6g1sx4hy1nxk07ddm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/eadfe12024ec1daccf3df3364cb402cd24db9de2.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/b3e3fcf59255ae0b5988b4cda61d3cff1415c36d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "8b44925075be15564a15e7d5cd1812974ae1eb69",
-        "sha256": "10mg5nnrs6phrjlhibvrz97v8sxncw3g88bldyps93pz6scrl3i5",
+        "rev": "2be16b7380b3f1db71668db583fc0c02e0e9ef1e",
+        "sha256": "03mc3ywdnm6y80k1hpaaqm068kv8j1xdbqcys2zx26w9la9svx3z",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/8b44925075be15564a15e7d5cd1812974ae1eb69.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/2be16b7380b3f1db71668db583fc0c02e0e9ef1e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "2966c58507c22b58e0698f0536ca182ff67a4e39",
-        "sha256": "1xa994d2rra7qpiqhlq7m6wcwbdkvjy0zispah30jk0mgg6s2rfp",
+        "rev": "8b44925075be15564a15e7d5cd1812974ae1eb69",
+        "sha256": "10mg5nnrs6phrjlhibvrz97v8sxncw3g88bldyps93pz6scrl3i5",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/2966c58507c22b58e0698f0536ca182ff67a4e39.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/8b44925075be15564a15e7d5cd1812974ae1eb69.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "2be16b7380b3f1db71668db583fc0c02e0e9ef1e",
-        "sha256": "03mc3ywdnm6y80k1hpaaqm068kv8j1xdbqcys2zx26w9la9svx3z",
+        "rev": "0b60c121daf45646ec8b3405852de1b81ecf18fc",
+        "sha256": "1wcmfbgjv8393b7k9g0ln0fnsmg7ngmiigd6acxvf8sz7j4im4vw",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/2be16b7380b3f1db71668db583fc0c02e0e9ef1e.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/0b60c121daf45646ec8b3405852de1b81ecf18fc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "0b60c121daf45646ec8b3405852de1b81ecf18fc",
-        "sha256": "1wcmfbgjv8393b7k9g0ln0fnsmg7ngmiigd6acxvf8sz7j4im4vw",
+        "rev": "fee0b00c1436e6a0e5db58f75ae3b23e8d4be107",
+        "sha256": "17nln2shkd0m3s7a6kbrr9h786qp62dp3j6ya44ifn7bvz289wks",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/0b60c121daf45646ec8b3405852de1b81ecf18fc.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/fee0b00c1436e6a0e5db58f75ae3b23e8d4be107.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -213,15 +213,12 @@ describe('Starting cardano-wallet (and its node)', () => {
             try {
               expect(status.wallet.code).toBe(0);
               expect(status.node.code).not.toBe(0);
-              // cardano-node is sometimes not exiting properly on both linux
-              // and windows.
-              // fixme: This assertion is disabled until the node is fixed.
               if (status.node.signal !== null) {
+                // cardano-node is sometimes not exiting properly on both linux
+                // and windows. Highlight this in the test logs.
                 loggers.test.error("Flaky test - cardano-node did not exit properly.", status.node.signal);
               }
-              // expect(status.node.signal).toBeNull();
-              // Maintain same number of assertions...
-              expect(status.node).not.toBeNull();
+              expect(status.node.signal).toBeNull();
             } catch (e) {
               fail(e);
             }


### PR DESCRIPTION
This updates the cardano-node revision to the branch of PR input-output-hk/cardano-node#3320, wherein the `--shutdown-ipc` functionality has been refactored.

```
niv add github input-output-hk/cardano-node \
    --branch jordan/separate-shutdown-ipc-shutdown-on-slot
```

cc: @Jimbo4350
