### PR TITLE
Exit cardano-node when verifying blockchain

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -304,6 +304,7 @@ export function setupService(
         } else {
           closeFD();
         }
+        proc.kill('SIGTERM');
       }
     }
     killTimer = setTimeout(() => {


### PR DESCRIPTION
Fix that solves the issue when stopping cardano-node at the very beginning when Daedalus starts and it is synchronizing.

**Issue**
When Daedalus is closed cardano-node is not being stopped.

**Description**
Even though Daedalus calls [node.stop](https://github.com/input-output-hk/daedalus/blob/66427855ff4eb513b9500d91bafc7baafa6e6db3/source/main/cardano/CardanoNode.js#L456) nothing happens.

**Problem in cardano-launcher**
The [switch case](https://github.com/input-output-hk/cardano-launcher/blob/b48819ff5b5fb9ade95c91d26309881cbbfaea8a/src/service.ts#L386) `ServiceStatus.Started` is evaluated
The problem is that the `if` inside the function `[doStop(timeoutSeconds)](https://github.com/input-output-hk/cardano-launcher/blob/b48819ff5b5fb9ade95c91d26309881cbbfaea8a/src/service.ts#L290)` is evaluated false (because `cfg.shutdownMethod = 2`) that is why in the `else` cardano-node is never stopped.

**Solution**
Adding `proc.kill('SIGTERM');` in the else.