### PR TITLE
Remove "cardano-node run --host-ipv6-addr=::1" default

### DIFF
--- a/src/cardanoNode.ts
+++ b/src/cardanoNode.ts
@@ -235,8 +235,11 @@ function makeArgs(
     delegationCertificate: config.delegationCertificate,
     listen: {
       port: listenPort,
+      // Listen for TCP connections on the loopback interface.
+      // We don't want to listen on 0.0.0.0 by default.
       address: '127.0.0.1',
-      address6: '::1',
+      // Don't listen on IPv6 at all -- this would fail if IPv6 is disabled.
+      address6: undefined,
     },
     configFile: path.join(config.configurationDir, config.network.configFile),
     signingKey: config.signingKey,


### PR DESCRIPTION
If the user's system has IPv6 disabled, passing this option will cause cardano-node to fail and exit.

Since all we wish to do is prevent exposing the node to the Internet, it's better to just not listen on IPv6 at all - by default.

### Comments

/cc @nc6 @Jimbo4350 

### Issue number

ADP-1334
