### PR TITLE
github actions: Fix workflow_dispatch trigger for npm upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,11 @@ on:
       # Could maybe use "created" type here instead.
       - published
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish NPM package with access? (public/restricted)'
+        required: true
+        default: 'public'
 
 jobs:
   linux:
@@ -127,9 +132,20 @@ jobs:
 
   publish-npm-package:
     name: 'Publish NPM Package'
-    if: '${{ github.event.release || github.event.workflow_dispatch }}'
+    if: "${{ github.event.release || ( ( startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' ) && github.event.inputs.publish ) }}"
     runs-on: ubuntu-20.04
+    env:
+      publish: '${{ github.event.inputs.publish }}'
     steps:
+      - name: ':octocat: Validate inputs'
+        if: '${{ env.publish }}'
+        run: |
+          if [ "$publish" = public || "$publish" = restricted ]; then
+            echo "Going to npm publish --access $publish"
+          else
+            echo "Unexpected value for 'publish' workflow input."
+            exit 1
+          fi
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2
         with:
@@ -138,6 +154,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       # Publish to npm
-      - run: npm publish --access public
+      - run: 'npm publish --access ${publish:-public}'
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This change should hopefully fix the `workflow_dispatch` trigger for the npm publishing CI step.

Normally, a github release event will cause the npm package to be published. But we might want to publish the package before properly releasing so that it can be tested.

In this case we would visit the [Actions](https://github.com/input-output-hk/cardano-launcher/actions/workflows/main.yml) page and click the "Run Workflow (dispatch)" button.

### Issue Number

ADP-1376